### PR TITLE
Update protocol v19 hash to Paris B2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.19.1
+* Update Paris protocol to [ParisB2](https://research-development.nomadic-labs.com/parisB2-announcement.html)
+
 ## v1.19.0
 
 * BREAKING CHANGE: The cannonical import part has been changed from `blockwatch.cc` to `github.com/trilitech`

--- a/tezos/protocols.go
+++ b/tezos/protocols.go
@@ -25,7 +25,7 @@ var (
 	ProtoV016_2    = MustParseProtocolHash("PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1")
 	ProtoV017      = MustParseProtocolHash("PtNairobiyssHuh87hEhfVBGCVrK3WnS8Z2FT4ymB5tAa4r1nQf")
 	ProtoV018      = MustParseProtocolHash("ProxfordYmVfjWnRcgjWH36fW6PArwqykTFzotUxRs6gmTcZDuH")
-	ProtoV019      = MustParseProtocolHash("PtParisBQscdCm6Cfow6ndeU6wKJyA3aV1j4D3gQBQMsTQyJCrz")
+	ProtoV019      = MustParseProtocolHash("PtParisBxoLz5gzMmn3d9WBQNoPSZakgnkMC2VNuQ3KXfUtUQeZ")
 
 	// aliases
 	PtAthens  = ProtoV004


### PR DESCRIPTION
As stated in the [announcement](https://research-development.nomadic-labs.com/parisB2-announcement.html).