### PR TITLE
Micheline encoding fix

### DIFF
--- a/micheline/primitives.go
+++ b/micheline/primitives.go
@@ -1494,6 +1494,9 @@ func (p *Prim) DecodeBuffer(buf *bytes.Buffer) error {
 			p.Args = append(p.Args, prim)
 		}
 		// annotation array byte size
+		if buf.Len() < 4 {
+			return io.ErrShortBuffer
+		}
 		size = int(binary.BigEndian.Uint32(buf.Next(4)))
 		if buf.Len() < size {
 			return io.ErrShortBuffer


### PR DESCRIPTION
A bug in TzGo Micheline encoding which impacts mainnet (decoding of params for set_delegate_parameters fails because the binary encoding is wrong). Issue is not being able to get a transaction list.