### PR TITLE
Params SnapshotBlock bounding fix

### DIFF
--- a/tezos/params.go
+++ b/tezos/params.go
@@ -265,7 +265,8 @@ func (p *Params) CycleFromHeight(height int64) int64 {
 func (p *Params) CycleStartHeight(c int64) int64 {
 	// adjust to target cycle
 	at := p.AtCycle(c)
-	return at.StartHeight - at.StartOffset + (c-at.StartCycle)*at.BlocksPerCycle
+	res := at.StartHeight - at.StartOffset + (c-at.StartCycle)*at.BlocksPerCycle
+	return res
 }
 
 func (p *Params) CycleEndHeight(c int64) int64 {
@@ -313,7 +314,11 @@ func (p *Params) SnapshotBlock(cycle int64, index int) int64 {
 	if base < 0 {
 		return 0
 	}
-	return at.CycleStartHeight(base) + int64(index+1)*at.BlocksPerSnapshot - 1
+	offset := int64(index+1) * at.BlocksPerSnapshot
+	if offset > at.BlocksPerCycle {
+		offset = at.BlocksPerCycle
+	}
+	return at.CycleStartHeight(base) + offset - 1
 }
 
 func (p *Params) SnapshotIndex(height int64) int {


### PR DESCRIPTION
`Params.SnapshotBlock()` was calculating incorrect block (in the future). We fetched the similar fix we used in similar other implementations. 