### PR TITLE
Support baker_own_stake and baker_edge in balance update

### DIFF
--- a/rpc/balance.go
+++ b/rpc/balance.go
@@ -34,9 +34,11 @@ type BalanceUpdate struct {
 
 	// Oxford staking
 	Staker struct {
-		Contract tezos.Address `json:"contract"` // tz1/2/3 accounts (only stake, unstake)
-		Delegate tezos.Address `json:"delegate"` // baker
-		Baker    tezos.Address `json:"baker"`    // baker
+		Contract      tezos.Address `json:"contract"`        // tz1/2/3 accounts (only stake, unstake)
+		Delegate      tezos.Address `json:"delegate"`        // baker
+		Baker         tezos.Address `json:"baker"`           // baker
+		BakerOwnStake tezos.Address `json:"baker_own_stake"` // baker: replaced baker in v19
+		BakerEdge     tezos.Address `json:"baker_edge"`      // baker: new in v19
 	} `json:"staker"`
 	DelayedOp tezos.OpHash `json:"delayed_operation_hash"`
 }
@@ -83,6 +85,10 @@ func (b BalanceUpdate) Address() tezos.Address {
 		return b.Staker.Delegate
 	case b.Staker.Baker.IsValid():
 		return b.Staker.Baker
+	case b.Staker.BakerOwnStake.IsValid():
+		return b.Staker.BakerOwnStake
+	case b.Staker.BakerEdge.IsValid():
+		return b.Staker.BakerEdge
 	}
 	return tezos.Address{}
 }


### PR DESCRIPTION
## What

Support new staker type `baker_own_stake` and `baker_edge` in balance update records.

Note that the `Address` method might have some issues since it returns only one address from a balance update record as the main address while it's possible to have multiple addresses in a balance update record. This is not dealt with here.

## Why

`baker_own_stake` and `baker_edge` are two types of stakers in a balance update record introduced in v19. They replace `baker` that was introduced in v18.

A balance update record with `baker_own_stake` looks like:

```json
{
     "kind": "freezer",
     "category": "deposits",
     "staker": {
           "baker_own_stake": "tz1LRhwjyec7ueCg4A2bPt8nNbfSMHeySkXm"
     },
     "change": "6000000000",
     "origin": "block"
}
```

## Test

Tested locally with the following code snippet:

```go
package main

import (
	"context"
	"fmt"

	"github.com/trilitech/tzgo/rpc"
	"github.com/trilitech/tzgo/tezos"
)

func main() {
	// init SDK client
	c, _ := rpc.NewClient("http://localhost:8732", nil)

	// all SDK functions take a context, here we just use a dummy
	ctx := context.TODO()
	id := tezos.MustParseBlockHash("BKoxYdxYzpGWZgocf3kUJR3ZoeohUocvcvx8t8r13qwXkThptkt")
	resp, _ := c.GetBlockOperations(ctx, id)
	for _, v := range resp {
		for _, vv := range v {
			for _, b := range vv.Contents[0].Result().BalanceUpdates {
				fmt.Printf("stakers: %+v\n", b.Staker)
			}
		}
	}
}
```

and this gave

```sh
% ./main                                                                                                                                                            ✭
stakers: {Contract: Delegate: Baker: BakerOwnStake: BakerEdge:}
stakers: {Contract: Delegate: Baker: BakerOwnStake:tz1LRhwjyec7ueCg4A2bPt8nNbfSMHeySkXm BakerEdge:}
stakers: {Contract:tz1LRhwjyec7ueCg4A2bPt8nNbfSMHeySkXm Delegate:tz1VQKYRCVyheZ8CgPvSjRwMUCfRomGF9nsv Baker: BakerOwnStake: BakerEdge:}
stakers: {Contract: Delegate: Baker: BakerOwnStake: BakerEdge:}
```

`BakerOwnStake` was populated correctly when it was present in one of the balance update records.