### PR TITLE
fix concurrent map writes of protocol versions

### DIFF
--- a/rpc/delegates.go
+++ b/rpc/delegates.go
@@ -72,7 +72,7 @@ func (c *Client) ListActiveDelegates(ctx context.Context, id BlockID) (DelegateL
 	}
 	selector := "active=true"
 	if p.Version >= 13 {
-		selector = "with_minimal_stake=true"
+		selector += "&with_minimal_stake=true"
 	}
 	delegates := make(DelegateList, 0)
 	u := fmt.Sprintf("chains/main/blocks/%s/context/delegates?%s", id, selector)

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -123,7 +123,9 @@ func (p *Params) WithChainId(id ChainIdHash) *Params {
 func (p *Params) WithProtocol(h ProtocolHash) *Params {
 	var ok bool
 	p.Protocol = h
+	versionsMtx.RLock()
 	p.Version, ok = Versions[h]
+	versionsMtx.RUnlock()
 	if !ok {
 		var max int
 		for _, v := range Versions {
@@ -133,6 +135,8 @@ func (p *Params) WithProtocol(h ProtocolHash) *Params {
 			max = v
 		}
 		p.Version = max + 1
+		versionsMtx.Lock()
+		defer versionsMtx.Unlock()
 		Versions[h] = p.Version
 	}
 	switch {

--- a/tezos/protocols.go
+++ b/tezos/protocols.go
@@ -3,6 +3,8 @@
 
 package tezos
 
+import "sync"
+
 var (
 	ProtoAlpha     = MustParseProtocolHash("ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK")
 	ProtoGenesis   = MustParseProtocolHash("PrihK96nBAFSxVL1GLJTVhu9YnzkMFiBeuJRPA8NwuZVZCE1L6i")
@@ -52,7 +54,8 @@ var (
 	Parisnet  = MustParseChainIdHash("NetXR64bNAYkP4S")
 	ParisCnet = MustParseChainIdHash("NetXXWAHLEvre9b")
 
-	Versions = map[ProtocolHash]int{
+	versionsMtx = sync.RWMutex{}
+	Versions    = map[ProtocolHash]int{
 		ProtoGenesis:   0,
 		ProtoBootstrap: 0,
 		ProtoV001:      1,


### PR DESCRIPTION
Adds mutex locks around cached protocol versions to enable parallel creation of RPC clients. Without this fix, parallel creation could cause crashes due to concurrent map writes into the version map.