### PR TITLE
SnapshotBlock() fix

### DIFF
--- a/tezos/param_test.go
+++ b/tezos/param_test.go
@@ -88,17 +88,30 @@ func TestParamsStatic(t *testing.T) {
 }
 
 func TestQuebecCycleEnd(t *testing.T) {
-	var cycleEndResults = map[int64]int64{
-		821: 7667712,
-		822: 7692288,
-		823: 7723008,
-		824: 7753728,
-		825: 7784448,
+	for cycle, v := range cycleBlocks {
+		startHeight := v[0]
+		endHeight := v[1]
+		p := NewParams().WithChainId(Mainnet).AtBlock(startHeight)
+		if p.CycleEndHeight(cycle) != endHeight {
+			t.Errorf("CycleEndHeight(%d) mismatch: have=%d want=%d", cycle, p.CycleEndHeight(cycle), endHeight)
+		}
 	}
-	for cycle, height := range cycleEndResults {
-		p := NewParams().WithChainId(Mainnet).AtBlock(height - 500)
-		if p.CycleEndHeight(cycle) != height {
-			t.Errorf("CycleEndHeight(%d) mismatch: have=%d want=%d", cycle, p.CycleEndHeight(cycle), height)
+}
+
+func TestSnapshotBlock(t *testing.T) {
+	for cycle, v := range cycleBlocks {
+		startCycle := v[0]
+		snapCycle := v[2]
+		p := NewParams().WithChainId(Mainnet).AtBlock(startCycle)
+
+		if have, want := p.SnapshotBlock(cycle, 0), snapCycle; have != want {
+			t.Errorf("SnapshotBlock(%d, %d) mismatch: have=%d want=%d", 15, cycle, have, want)
+		}
+		if have, want := p.SnapshotBlock(cycle, 15), snapCycle; have != want {
+			t.Errorf("SnapshotBlock(%d, %d) mismatch: have=%d want=%d", 15, cycle, have, want)
+		}
+		if have, want := p.SnapshotBlock(cycle, 11), snapCycle; have != want {
+			t.Errorf("SnapshotBlock(%d, %d) mismatch: have=%d want=%d", 11, cycle, have, want)
 		}
 	}
 }
@@ -242,6 +255,16 @@ func (p paramResult) IsVoteStart() bool {
 
 func (p paramResult) IsVoteEnd() bool {
 	return p.Flags&0x1 > 0
+}
+
+var cycleBlocks = map[int64][]int64{
+	826: {7784449, 7815168, 7723008},
+	825: {7753729, 7784448, 7692288},
+	824: {7723009, 7753728, 7667712},
+	823: {7692289, 7723008, 7643136}, // first quebec cycle
+	822: {7667713, 7692288, 7618560},
+	821: {7643137, 7667712, 7593984},
+	820: {7618561, 7643136, 7569408},
 }
 
 var paramResults = map[int64]paramResult{

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -262,14 +262,18 @@ func (p *Params) IsSnapshotBlock(height int64) bool {
 
 func (p *Params) SnapshotBlock(cycle int64, index int) int64 {
 	// adjust to target cycle
+	if p.Version > 18 {
+		index = 15
+	}
 	at := p.AtCycle(cycle)
 	base := at.SnapshotBaseCycle(cycle)
+	baseBlocksPerSnapshot := p.AtCycle(base).BlocksPerSnapshot
 	if base < 0 {
 		return 0
 	}
-	offset := int64(index+1) * at.BlocksPerSnapshot
-	if offset > at.BlocksPerCycle {
-		offset = at.BlocksPerCycle
+	offset := int64(index+1) * baseBlocksPerSnapshot
+	if offset > baseBlocksPerSnapshot {
+		offset = baseBlocksPerSnapshot
 	}
 	return at.CycleStartHeight(base) + offset - 1
 }


### PR DESCRIPTION
### Why
The `Params.SnapshotBlock(cycle, snapIndex)` function was not working correctly after Quebec update. A bug was introduced in this function during Paris protocol update as we were considering the `BlocksPerSnapshot` constant of the current cycle rather than the one at the base cycle. This would throw off the snapshot block calculation for the migration cycles (i.e the cycles in Quebec whose base cycle is in Paris).

### What
- Fixed the SnapshotBlock function implementation to use `BlocksPerSnapshot` constant as the base cycle.
- Made the index (snapshot index) param of the SnapshotBlock function inconsequential (i.e any value can be passed) for protocol versions 19 and above (Paris and later) where the snapshot indexes were dropped.
- Added a few tests to validate `SnapshotBlock()` and `CycleEndHeight()` functions.