### PR TITLE
tezos: register protocol v025 (Ushuaia) [BIN-917]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### [Ushuaia Protocol (v025)](https://octez.tezos.com/docs/protocols/025_u025.html) Support
+
+#### Protocol Registration
+* Registered protocol `ProtoV025` (`PsUshuai9QapM5TGj1JpuVGkdxz5GykdnEvS6Rh8SUVrARvZLCY`) with alias `PsUshuai`; bumped `ProtoAlpha` to version 26 so it no longer collides with the v025 slot
+* Fixed `WithProtocol` to assign `OperationTagsVersion = 4` for protocols v023+ (was capped at 3); tag encoding is unchanged (v2+ tag table)
+* Deployment rows and `DefaultParams`/`GhostnetParams`/`ShadownetParams` repointing deferred until activation heights are published
+
 ## v1.24.0
 
 ### [Tallinn Protocol](https://octez.tezos.com/docs/protocols/024_tallinn.html) Support 

--- a/tezos/param_test.go
+++ b/tezos/param_test.go
@@ -172,7 +172,7 @@ func TestDefaultParams(t *testing.T) {
 		if p.MaxOperationDataLength == 0 {
 			t.Errorf("%s params: zero MaxOperationDataLength", n)
 		}
-		if p.OperationTagsVersion < 0 || p.OperationTagsVersion > 3 {
+		if p.OperationTagsVersion < 0 || p.OperationTagsVersion > 4 {
 			t.Errorf("%s params: unknown OperationTagsVersion %d", n, p.OperationTagsVersion)
 		}
 		if p.StartHeight == 0 {

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -180,7 +180,8 @@ func (p *Params) WithProtocol(h ProtocolHash) *Params {
 		Versions[h] = p.Version
 	}
 	switch {
-	// FIXME: tagv4 from v023
+	case p.Version > 22:
+		p.OperationTagsVersion = 4
 	case p.Version > 18:
 		p.OperationTagsVersion = 3
 	case p.Version > 11:

--- a/tezos/protocols.go
+++ b/tezos/protocols.go
@@ -33,6 +33,7 @@ var (
 	ProtoV022      = MustParseProtocolHash("PsRiotumaAMotcRoDWW1bysEhQy2n1M5fy8JgRp8jjRfHGmfeA7")
 	ProtoV023      = MustParseProtocolHash("PtSeouLouXkxhg39oWzjxDWaCydNfR3RxCUrNe4Q9Ro8BTehcbh")
 	ProtoV024      = MustParseProtocolHash("PtTALLiNtPec7mE7yY4m3k26J8Qukef3E3ehzhfXgFZKGtDdAXu")
+	ProtoV025      = MustParseProtocolHash("PsUshuai9QapM5TGj1JpuVGkdxz5GykdnEvS6Rh8SUVrARvZLCY")
 
 	// aliases
 	PtAthens  = ProtoV004
@@ -56,6 +57,7 @@ var (
 	PsRiotum  = ProtoV022
 	PtSeouLo  = ProtoV023
 	PtTallin  = ProtoV024
+	PsUshuai  = ProtoV025
 
 	Mainnet   = MustParseChainIdHash("NetXdQprcVkpaWU")
 	Ghostnet  = MustParseChainIdHash("NetXnHfVqm9iesp")
@@ -89,7 +91,8 @@ var (
 		ProtoV022:      22,
 		ProtoV023:      23,
 		ProtoV024:      24,
-		ProtoAlpha:     25,
+		ProtoV025:      25,
+		ProtoAlpha:     26,
 	}
 
 	Deployments = map[ChainIdHash]ProtocolHistory{

--- a/tezos/protocols_test.go
+++ b/tezos/protocols_test.go
@@ -1,0 +1,33 @@
+package tezos_test
+
+import (
+	"testing"
+
+	"github.com/trilitech/tzgo/tezos"
+)
+
+// TestProtoV025Registration verifies that protocol v025 (Ushuaia) is registered
+// with the expected version number and that ProtoAlpha is bumped past it.
+func TestProtoV025Registration(t *testing.T) {
+	if got := tezos.Versions[tezos.ProtoV025]; got != 25 {
+		t.Errorf("ProtoV025 version = %d, want 25", got)
+	}
+	if got := tezos.Versions[tezos.ProtoAlpha]; got != 26 {
+		t.Errorf("ProtoAlpha version = %d, want 26 (must not collide with v025)", got)
+	}
+	if !tezos.PsUshuai.Equal(tezos.ProtoV025) {
+		t.Errorf("PsUshuai alias does not equal ProtoV025")
+	}
+}
+
+// TestWithProtocolV025 verifies WithProtocol resolves v025 to version 25 and
+// operation tags version 4 (v23+).
+func TestWithProtocolV025(t *testing.T) {
+	p := tezos.NewParams().WithProtocol(tezos.ProtoV025)
+	if p.Version != 25 {
+		t.Errorf("v025 params Version = %d, want 25", p.Version)
+	}
+	if p.OperationTagsVersion != 4 {
+		t.Errorf("v025 params OperationTagsVersion = %d, want 4", p.OperationTagsVersion)
+	}
+}


### PR DESCRIPTION
## Summary

Item **1** of BIN-878 — make TzGo aware of protocol v025 (Ushuaia).

- Register `ProtoV025` = `PsUshuai9QapM5TGj1JpuVGkdxz5GykdnEvS6Rh8SUVrARvZLCY` with alias `PsUshuai`, following the v024 pattern.
- `Versions`: add `ProtoV025: 25` and bump `ProtoAlpha: 26` (was `25`, which collided with the slot a real v025 takes).
- Fix `WithProtocol` to assign `OperationTagsVersion = 4` for protocols v023+ (was capped at `3`). **No encoding change** — `OpType.TagVersion` routes every `v >= 2` through the same `opTagV2` table, so the field is metadata only; the test bound was updated accordingly.

## Deferred (not guessed)

Ushuaia is still in governance, so **activation heights are not published**. Therefore:
- No `Deployment{}` rows added for Mainnet/Ghostnet/Shadownet yet.
- `DefaultParams`/`GhostnetParams`/`ShadownetParams` remain pinned to `ProtoV024`.

These should be a follow-up once activation heights are known (tracked in BIN-917 acceptance).

## Tests

- New `tezos/protocols_test.go`: verifies v025 registration, ProtoAlpha bump, alias, and `WithProtocol(ProtoV025)` → version 25 / tags v4.
- `go test ./tezos/` green; `go vet ./tezos/` clean.

> Note: pre-existing failures in the untracked `codec/smart_rollup_test.go` WIP file are unrelated to this change (they reproduce on `master` without these edits) and are not included here.

Part of BIN-878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)