### PR TITLE
rpc: support v025 (Ushuaia) DAL changes [BIN-918]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### [Ushuaia Protocol (v025)](https://octez.tezos.com/docs/protocols/025_u025.html) Support
+
+#### DAL Changes (BREAKING)
+* `DalEntrapmentEvidence` - added optional `LagIndex` (`lag_index`) field for the new dynamic attestation lag; nil for pre-v025 blocks
+* `Endorsement.DalAttestation` / `Committee.DalAttestation` - documented the BREAKING change to DAL attestation bitset semantics in v025 (baker-attested vs protocol-attested slots, multi-lag layout). The value still decodes as a `Z`; only bit-level interpretation changed
+
 ## v1.24.0
 
 ### [Tallinn Protocol](https://octez.tezos.com/docs/protocols/024_tallinn.html) Support 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### [Ushuaia Protocol (v025)](https://octez.tezos.com/docs/protocols/025_u025.html) Support
 
 
-#### DAL Changes (BREAKING)
+#### DAL Changes (BREAKING, see [Ushuaia "Breaking Changes"](https://octez.tezos.com/docs/protocols/025_u025.html#breaking-changes))
 * `DalEntrapmentEvidence` - added optional `LagIndex` (`lag_index`) field for the new dynamic attestation lag; nil for pre-v025 blocks
-* `Endorsement.DalAttestation` / `Committee.DalAttestation` - documented the BREAKING change to DAL attestation bitset semantics in v025 (baker-attested vs protocol-attested slots, multi-lag layout). The value still decodes as a `Z`; only bit-level interpretation changed
+* `Endorsement.DalAttestation` / `Committee.DalAttestation` - documented the BREAKING change to DAL attestation bitset semantics in v025 (baker-attested vs protocol-attested slots, multi-lag layout). The value still decodes as a `Z`; only bit-level interpretation changed. Use the node's `decode_dal_attestation`/`encode_dal_attestation` helper RPCs to interpret v025+ bitsets
 
 #### Protocol Registration
 * Registered protocol `ProtoV025` (`PsUshuai9QapM5TGj1JpuVGkdxz5GykdnEvS6Rh8SUVrARvZLCY`) with alias `PsUshuai`; bumped `ProtoAlpha` to version 26 so it no longer collides with the v025 slot

--- a/rpc/attestations_aggregate.go
+++ b/rpc/attestations_aggregate.go
@@ -21,7 +21,11 @@ type ConsensusContent struct {
 }
 
 type Committee struct {
-	Slot           int     `json:"slot"`            // v023+
+	Slot int `json:"slot"` // v023+
+	// DalAttestation is a raw bitset of attested DAL slots. v023+.
+	// BREAKING in v025 (Ushuaia): the bit semantics changed (baker-attested vs
+	// protocol-attested slots) and a multi-lag layout was introduced. See the
+	// note on Endorsement.DalAttestation.
 	DalAttestation tezos.Z `json:"dal_attestation"` // v023+
 }
 

--- a/rpc/dal_entrapment_evidence.go
+++ b/rpc/dal_entrapment_evidence.go
@@ -44,4 +44,8 @@ type DalEntrapmentEvidence struct {
 	ConsensusSlot  uint16             `json:"consensus_slot"`
 	SlotIndex      uint8              `json:"slot_index"`
 	ShardWithProof ShardWithProof     `json:"shard_with_proof"`
+	// LagIndex identifies which attestation lag (an index into the
+	// attestation_lags parameter list) the evidence refers to. Added in v025
+	// (Ushuaia) together with dynamic attestation lag; nil for pre-v025 blocks.
+	LagIndex *uint8 `json:"lag_index,omitempty"`
 }

--- a/rpc/dal_entrapment_evidence.go
+++ b/rpc/dal_entrapment_evidence.go
@@ -8,10 +8,14 @@ import "encoding/json"
 // Ensure DalEntrapmentEvidence implements the TypedOperation interface.
 var _ TypedOperation = (*DalEntrapmentEvidence)(nil)
 
+// RawShard holds one element of a shard_with_proof.shard array, which the
+// node encodes either as an integer (the shard index) or as a list of hex
+// strings (the shard data). Use AsInt or AsStringSlice to interpret it.
 type RawShard struct {
 	json.RawMessage
 }
 
+// AsInt interprets the raw shard element as an integer shard index.
 func (s RawShard) AsInt() (int, error) {
 	var value int
 	if s.RawMessage == nil {
@@ -21,6 +25,7 @@ func (s RawShard) AsInt() (int, error) {
 	return value, err
 }
 
+// AsStringSlice interprets the raw shard element as a list of hex strings.
 func (s RawShard) AsStringSlice() ([]string, error) {
 	var value []string
 	if s.RawMessage == nil {
@@ -30,6 +35,8 @@ func (s RawShard) AsStringSlice() ([]string, error) {
 	return value, err
 }
 
+// ShardWithProof is a DAL shard together with its inclusion proof as carried
+// by dal_entrapment_evidence operations.
 type ShardWithProof struct {
 	// `shard` can be either an integer or a list of strings
 	// https://gitlab.com/tezos/tezos/-/blob/2c16b5170ad3305538cba6cbc636ef7560531f05/docs/api/seoul-openapi.json#L15621
@@ -44,8 +51,11 @@ type DalEntrapmentEvidence struct {
 	ConsensusSlot  uint16             `json:"consensus_slot"`
 	SlotIndex      uint8              `json:"slot_index"`
 	ShardWithProof ShardWithProof     `json:"shard_with_proof"`
-	// LagIndex identifies which attestation lag (an index into the
-	// attestation_lags parameter list) the evidence refers to. Added in v025
-	// (Ushuaia) together with dynamic attestation lag; nil for pre-v025 blocks.
+	// LagIndex identifies which attestation lag the evidence refers to: an
+	// index into the attestation_lags protocol constant (see the
+	// dal_parametric block of the chain constants, surfaced as
+	// tezos.Params.DalAttestationLags). Added in v025 (Ushuaia) together with
+	// dynamic attestation lag; nil for pre-v025 blocks. Note that a present
+	// zero value ("lag_index": 0) is distinct from an absent field.
 	LagIndex *uint8 `json:"lag_index,omitempty"`
 }

--- a/rpc/dal_entrapment_evidence_test.go
+++ b/rpc/dal_entrapment_evidence_test.go
@@ -202,3 +202,36 @@ func TestDalEntrapmentEvidenceLagIndex(t *testing.T) {
 	}
 	assert.Nil(t, op2.LagIndex)
 }
+
+// TestDalEntrapmentEvidenceLagIndexMarshal locks the omitempty contract for the
+// pointer field: nil omits the key entirely, while a present zero value emits
+// "lag_index":0 and survives a marshal/unmarshal round trip distinct from nil.
+func TestDalEntrapmentEvidenceLagIndexMarshal(t *testing.T) {
+	// nil pointer: key must be absent
+	var op DalEntrapmentEvidence
+	op.OpKind = tezos.OpTypeDalEntrapmentEvidence
+	buf, err := json.Marshal(op)
+	if err != nil {
+		t.Fatalf("marshal without lag_index: %v", err)
+	}
+	assert.NotContains(t, string(buf), "lag_index")
+
+	// pointer to zero: key must be present with value 0 (distinct from nil)
+	zero := uint8(0)
+	op.LagIndex = &zero
+	buf, err = json.Marshal(op)
+	if err != nil {
+		t.Fatalf("marshal with zero lag_index: %v", err)
+	}
+	assert.Contains(t, string(buf), `"lag_index":0`)
+
+	// decode of an explicit zero from node JSON is non-nil: the round trip of
+	// a present zero value is preserved and stays distinct from nil
+	var op3 DalEntrapmentEvidence
+	if err := json.Unmarshal([]byte(`{"kind": "dal_entrapment_evidence", "lag_index": 0}`), &op3); err != nil {
+		t.Fatalf("unmarshal explicit zero lag_index: %v", err)
+	}
+	if assert.NotNil(t, op3.LagIndex) {
+		assert.Equal(t, uint8(0), *op3.LagIndex)
+	}
+}

--- a/rpc/dal_entrapment_evidence_test.go
+++ b/rpc/dal_entrapment_evidence_test.go
@@ -167,4 +167,38 @@ func TestParseDalEntrapmentEvidence(t *testing.T) {
 	assert.Equal(t, "69494c5d6a472b7ad772a5ffb816530c02ef84ca4695ee59fb77ab7d53daa05d", stringShard[0])
 	assert.Equal(t, "1dc980199e4e1f73c9776ff357123107d513e044d765ef4a47567f3013595603", stringShard[63])
 	assert.Equal(t, "sh1whSSiBcztN8LCEvjebGwVfCyueMdkAe8ZFtZDF4A9nwF5AznfCwEZuComZtsodbkAsdBGkz", ops[0].ShardWithProof.Proof)
+	// pre-v025 evidence has no lag_index
+	assert.Nil(t, ops[0].LagIndex)
+}
+
+// TestDalEntrapmentEvidenceLagIndex verifies the optional v025 lag_index field
+// decodes when present and stays nil when absent.
+func TestDalEntrapmentEvidenceLagIndex(t *testing.T) {
+	withLag := `{
+		"kind": "dal_entrapment_evidence",
+		"attestation": {
+			"branch": "BMLJapq1nxNo67Cak9nyU9p6EZ8DGK5NFjc4nVQYXwhHdmapAz7",
+			"operations": {"kind": "attestation_with_dal", "slot": 6, "level": 13151123, "round": 0, "block_payload_hash": "vh1he5NXZcwZmGe3cGdepQU83C6Qky7m1tWJsShNnjT7amg8X7Jy", "dal_attestation": "42"},
+			"signature": "sigrP9miXpMmFZpn8TbAy1j8RPFTvrzLHDE6ZtrFCQ4q7E1dzRomHXxca8SAtXtdj95s5CcZhMvm1nYQBQgcAxu7JGgiof5N"
+		},
+		"consensus_slot": 6,
+		"slot_index": 15,
+		"lag_index": 3,
+		"shard_with_proof": {"shard": [403], "proof": "sh1whSSiBcztN8LCEvjebGwVfCyueMdkAe8ZFtZDF4A9nwF5AznfCwEZuComZtsodbkAsdBGkz"}
+	}`
+
+	var op DalEntrapmentEvidence
+	if err := json.Unmarshal([]byte(withLag), &op); err != nil {
+		t.Fatalf("unmarshal with lag_index: %v", err)
+	}
+	if assert.NotNil(t, op.LagIndex) {
+		assert.Equal(t, uint8(3), *op.LagIndex)
+	}
+
+	withoutLag := `{"kind": "dal_entrapment_evidence", "consensus_slot": 6, "slot_index": 15, "shard_with_proof": {"shard": [403], "proof": "x"}}`
+	var op2 DalEntrapmentEvidence
+	if err := json.Unmarshal([]byte(withoutLag), &op2); err != nil {
+		t.Fatalf("unmarshal without lag_index: %v", err)
+	}
+	assert.Nil(t, op2.LagIndex)
 }

--- a/rpc/endorsement.go
+++ b/rpc/endorsement.go
@@ -19,10 +19,18 @@ type Endorsement struct {
 	Round       int                 `json:"round"`                 // v012+
 	PayloadHash tezos.PayloadHash   `json:"block_payload_hash"`    // v012+
 	// DalAttestation is a raw bitset of attested DAL slots. v019+.
+	//
 	// BREAKING in v025 (Ushuaia): the bit semantics changed (baker-attested vs
 	// protocol-attested slots) and a multi-lag layout was introduced. The value
-	// still decodes as a Z, but code that interprets individual bits must account
-	// for the new layout for v025+ blocks.
+	// still decodes as a Z, but the bit layout is protocol-dependent: for
+	// v024 and earlier, bit i means slot i is attested; from v025 on, the
+	// layout packs attested slots per attestation lag and individual bits
+	// MUST NOT be interpreted without protocol context. TzGo deliberately
+	// keeps this field opaque. To interpret a v025+ bitset, use the node's
+	// helper RPCs GET .../helpers/decode_dal_attestation/<bitset> and
+	// POST .../helpers/encode_dal_attestation, which translate between the
+	// bitset and an explicit list of attested slot indices per lag using the
+	// protocol parameters active at the queried block.
 	DalAttestation tezos.Z `json:"dal_attestation"` // v019+
 }
 

--- a/rpc/endorsement.go
+++ b/rpc/endorsement.go
@@ -18,7 +18,12 @@ type Endorsement struct {
 	Slot           int                 `json:"slot"`                  // v009+
 	Round          int                 `json:"round"`                 // v012+
 	PayloadHash    tezos.PayloadHash   `json:"block_payload_hash"`    // v012+
-	DalAttestation tezos.Z             `json:"dal_attestation"`       // v019+
+	// DalAttestation is a raw bitset of attested DAL slots. v019+.
+	// BREAKING in v025 (Ushuaia): the bit semantics changed (baker-attested vs
+	// protocol-attested slots) and a multi-lag layout was introduced. The value
+	// still decodes as a Z, but code that interprets individual bits must account
+	// for the new layout for v025+ blocks.
+	DalAttestation tezos.Z `json:"dal_attestation"` // v019+
 }
 
 func (e Endorsement) GetLevel() int64 {

--- a/rpc/endorsement.go
+++ b/rpc/endorsement.go
@@ -13,11 +13,11 @@ var _ TypedOperation = (*Endorsement)(nil)
 // Endorsement represents an endorsement operation
 type Endorsement struct {
 	Generic
-	Level          int64               `json:"level"`                 // <= v008, v012+
-	Endorsement    *InlinedEndorsement `json:"endorsement,omitempty"` // v009+
-	Slot           int                 `json:"slot"`                  // v009+
-	Round          int                 `json:"round"`                 // v012+
-	PayloadHash    tezos.PayloadHash   `json:"block_payload_hash"`    // v012+
+	Level       int64               `json:"level"`                 // <= v008, v012+
+	Endorsement *InlinedEndorsement `json:"endorsement,omitempty"` // v009+
+	Slot        int                 `json:"slot"`                  // v009+
+	Round       int                 `json:"round"`                 // v012+
+	PayloadHash tezos.PayloadHash   `json:"block_payload_hash"`    // v012+
 	// DalAttestation is a raw bitset of attested DAL slots. v019+.
 	// BREAKING in v025 (Ushuaia): the bit semantics changed (baker-attested vs
 	// protocol-attested slots) and a multi-lag layout was introduced. The value


### PR DESCRIPTION
## Summary

Item **3** of BIN-878 — DAL-related changes in v025 (Ushuaia). **BREAKING** at the semantic level.

- **`DalEntrapmentEvidence.LagIndex`** — new optional `lag_index` field (`*uint8`, `omitempty`) for the dynamic attestation lag. `nil` for pre-v025 blocks.
- **`dal_attestation` bitset semantics** — documented the breaking change on `Endorsement.DalAttestation` and `Committee.DalAttestation`. The value still decodes as a `tezos.Z`; only the meaning of individual bits changed (baker-attested vs protocol-attested slots, plus the new multi-lag layout). No decode break — callers interpreting bits must update for v025+.

## Out of scope (deliberately)

- **DAL protocol constants** (`number_of_slots` → 160, slot size → 380,832, `attestation_lag` → 5, `attestation_lags`) are handled in the constants PR (BIN-919) to keep `rpc/constants.go` changes in one place.
- DAL page-validation / refutation-game lag-at-publication-time only matters if we model rollup DAL proofs — TzGo does not, so no change.

## Tests

- Extended `TestParseDalEntrapmentEvidence` to assert `LagIndex` is nil for the pre-v025 fixture.
- New `TestDalEntrapmentEvidenceLagIndex`: decodes `lag_index` when present, nil when absent.
- `go test ./rpc/` green; `go vet ./rpc/` clean.

Part of BIN-878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)