### PR TITLE
rpc,tezos: add v025 (Ushuaia) protocol constants [BIN-919]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### [Ushuaia Protocol (v025)](https://octez.tezos.com/docs/protocols/025_u025.html) Support
+
+#### Protocol Constants
+* `Constants` - decode the `dal_parametric` block into a new `DalParametric` struct (`number_of_slots` → 160, `slot_size` → 380832, `attestation_lag` → 5, and the new dynamic-lag list `attestation_lags`), plus the new top-level `cache_layout_size`
+* `tezos.Params` - added `DalNumberOfSlots`, `DalSlotSize`, `DalAttestationLag`, and `DalAttestationLags`; `MapToChainParams` now surfaces the DAL constants
+
 ## v1.24.0
 
 ### [Tallinn Protocol](https://octez.tezos.com/docs/protocols/024_tallinn.html) Support 

--- a/rpc/constants.go
+++ b/rpc/constants.go
@@ -47,26 +47,46 @@ type Constants struct {
 	SmartRollupTimeoutPeriodInBlocks    int64       `json:"smart_rollup_timeout_period_in_blocks"`
 	AllBakersAttestActivationThreshold  tezos.Ratio `json:"all_bakers_attest_activation_threshold"`
 
-	// DAL parameters, nested under dal_parametric. v019+; AttestationLags is new
-	// in v025 (Ushuaia, dynamic attestation lag).
+	// Dal holds the data-availability-layer parameters nested under the
+	// dal_parametric key. Present since v019; the AttestationLags vector is
+	// new in v025 (Ushuaia, dynamic attestation lag). Zero-valued on chains
+	// that predate the DAL.
 	Dal DalParametric `json:"dal_parametric"`
 
-	// Ushuaia additions (v025)
+	// Ushuaia additions
+	// CacheLayoutSize is the number of protocol cache layouts (v025: raised
+	// from 3 to 5). Zero on pre-v025 chains where the key is absent. This is
+	// internal protocol caching configuration and is intentionally not mapped
+	// into tezos.Params; read it from Constants (or GetCustomConstants).
 	CacheLayoutSize int64 `json:"cache_layout_size"`
 }
 
 // DalParametric holds the data-availability-layer protocol constants returned
 // under the dal_parametric key of the chain constants.
 type DalParametric struct {
-	FeatureEnable        bool    `json:"feature_enable"`
-	NumberOfSlots        int64   `json:"number_of_slots"`
-	SlotSize             int64   `json:"slot_size"`
-	PageSize             int64   `json:"page_size"`
-	NumberOfShards       int64   `json:"number_of_shards"`
-	RedundancyFactor     int64   `json:"redundancy_factor"`
-	AttestationLag       int64   `json:"attestation_lag"`
-	AttestationThreshold int64   `json:"attestation_threshold"`
-	AttestationLags      []int64 `json:"attestation_lags"` // v025+
+	// FeatureEnable reports whether the DAL is enabled on this chain.
+	FeatureEnable bool `json:"feature_enable"`
+	// NumberOfSlots is the number of DAL slots per block (v025: 160).
+	NumberOfSlots int64 `json:"number_of_slots"`
+	// SlotSize is the size of a DAL slot in bytes (v025: 380832).
+	SlotSize int64 `json:"slot_size"`
+	// PageSize is the size of a DAL page in bytes.
+	PageSize int64 `json:"page_size"`
+	// NumberOfShards is the number of shards a slot is split into.
+	NumberOfShards int64 `json:"number_of_shards"`
+	// RedundancyFactor is the erasure-coding redundancy factor.
+	RedundancyFactor int64 `json:"redundancy_factor"`
+	// AttestationLag is the legacy scalar attestation lag in blocks, still
+	// emitted for backward compatibility (v025 default: 5). From v025 on the
+	// canonical representation is the AttestationLags vector below.
+	AttestationLag int64 `json:"attestation_lag"`
+	// AttestationThreshold is the minimum percentage of attested shards
+	// required to declare a slot available.
+	AttestationThreshold int64 `json:"attestation_threshold"`
+	// AttestationLags lists the allowed attestation lags for the dynamic-lag
+	// mechanism introduced in v025 (Ushuaia), e.g. [1,2,3,4,5]. Nil on
+	// pre-v025 chains.
+	AttestationLags []int64 `json:"attestation_lags"`
 }
 
 // GetConstants returns chain configuration constants at block id

--- a/rpc/constants.go
+++ b/rpc/constants.go
@@ -46,6 +46,27 @@ type Constants struct {
 	SmartRollupMaxLookaheadInBlocks     int64       `json:"smart_rollup_max_lookahead_in_blocks"`
 	SmartRollupTimeoutPeriodInBlocks    int64       `json:"smart_rollup_timeout_period_in_blocks"`
 	AllBakersAttestActivationThreshold  tezos.Ratio `json:"all_bakers_attest_activation_threshold"`
+
+	// DAL parameters, nested under dal_parametric. v019+; AttestationLags is new
+	// in v025 (Ushuaia, dynamic attestation lag).
+	Dal DalParametric `json:"dal_parametric"`
+
+	// Ushuaia additions (v025)
+	CacheLayoutSize int64 `json:"cache_layout_size"`
+}
+
+// DalParametric holds the data-availability-layer protocol constants returned
+// under the dal_parametric key of the chain constants.
+type DalParametric struct {
+	FeatureEnable        bool    `json:"feature_enable"`
+	NumberOfSlots        int64   `json:"number_of_slots"`
+	SlotSize             int64   `json:"slot_size"`
+	PageSize             int64   `json:"page_size"`
+	NumberOfShards       int64   `json:"number_of_shards"`
+	RedundancyFactor     int64   `json:"redundancy_factor"`
+	AttestationLag       int64   `json:"attestation_lag"`
+	AttestationThreshold int64   `json:"attestation_threshold"`
+	AttestationLags      []int64 `json:"attestation_lags"` // v025+
 }
 
 // GetConstants returns chain configuration constants at block id
@@ -131,6 +152,20 @@ func (c Constants) MapToChainParams() *tezos.Params {
 	if c.AllBakersAttestActivationThreshold.Den != 0 {
 		p.AllBakersAttestActivationThreshold.Num = c.AllBakersAttestActivationThreshold.Num
 		p.AllBakersAttestActivationThreshold.Den = c.AllBakersAttestActivationThreshold.Den
+	}
+
+	// DAL parameters (v019+; attestation_lags new in v025)
+	if c.Dal.NumberOfSlots > 0 {
+		p.DalNumberOfSlots = c.Dal.NumberOfSlots
+	}
+	if c.Dal.SlotSize > 0 {
+		p.DalSlotSize = c.Dal.SlotSize
+	}
+	if c.Dal.AttestationLag > 0 {
+		p.DalAttestationLag = c.Dal.AttestationLag
+	}
+	if len(c.Dal.AttestationLags) > 0 {
+		p.DalAttestationLags = c.Dal.AttestationLags
 	}
 
 	// Paris blocks per snapshot

--- a/rpc/constants_test.go
+++ b/rpc/constants_test.go
@@ -62,3 +62,26 @@ func TestConstantsV025Dal(t *testing.T) {
 		t.Errorf("DalAttestationLags = %v, want length 5", p.DalAttestationLags)
 	}
 }
+
+// TestConstantsPreV025NoDal verifies that constants from chains without DAL
+// parameters (no dal_parametric key, no cache_layout_size) decode cleanly and
+// leave the DAL fields in tezos.Params zero-valued.
+func TestConstantsPreV025NoDal(t *testing.T) {
+	const blob = `{"blocks_per_cycle": 8192, "consensus_rights_delay": 2}`
+
+	var c Constants
+	if err := json.Unmarshal([]byte(blob), &c); err != nil {
+		t.Fatalf("unmarshal pre-v025 constants: %v", err)
+	}
+	if c.CacheLayoutSize != 0 {
+		t.Errorf("CacheLayoutSize = %d, want 0 on pre-v025 chains", c.CacheLayoutSize)
+	}
+	if c.Dal.NumberOfSlots != 0 || c.Dal.AttestationLag != 0 || c.Dal.AttestationLags != nil {
+		t.Errorf("unexpected non-zero DAL constants: %+v", c.Dal)
+	}
+
+	p := c.MapToChainParams()
+	if p.DalNumberOfSlots != 0 || p.DalSlotSize != 0 || p.DalAttestationLag != 0 || p.DalAttestationLags != nil {
+		t.Errorf("DAL params must stay zero without dal_parametric: %+v", p)
+	}
+}

--- a/rpc/constants_test.go
+++ b/rpc/constants_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/trilitech/tzgo/tezos"
@@ -17,5 +18,47 @@ func TestMapToChainParams_AllBakersAttestActivationThreshold(t *testing.T) {
 	}
 	if got := p.ActivationThresholdFloat(); got != 0.5 {
 		t.Fatalf("expected float 0.5, got %v", got)
+	}
+}
+
+// TestConstantsV025Dal verifies the v025 DAL parametric constants decode from
+// the dal_parametric object and are surfaced into tezos.Params.
+func TestConstantsV025Dal(t *testing.T) {
+	const blob = `{
+		"blocks_per_cycle": 10800,
+		"cache_layout_size": 5,
+		"dal_parametric": {
+			"feature_enable": true,
+			"number_of_slots": 160,
+			"slot_size": 380832,
+			"page_size": 3967,
+			"number_of_shards": 512,
+			"redundancy_factor": 8,
+			"attestation_lag": 5,
+			"attestation_threshold": 66,
+			"attestation_lags": [1, 2, 3, 4, 5]
+		}
+	}`
+
+	var c Constants
+	if err := json.Unmarshal([]byte(blob), &c); err != nil {
+		t.Fatalf("unmarshal constants: %v", err)
+	}
+	if c.CacheLayoutSize != 5 {
+		t.Errorf("CacheLayoutSize = %d, want 5", c.CacheLayoutSize)
+	}
+	if c.Dal.NumberOfSlots != 160 || c.Dal.SlotSize != 380832 || c.Dal.AttestationLag != 5 {
+		t.Errorf("unexpected DAL constants: %+v", c.Dal)
+	}
+	if len(c.Dal.AttestationLags) != 5 || c.Dal.AttestationLags[4] != 5 {
+		t.Errorf("AttestationLags = %v, want [1 2 3 4 5]", c.Dal.AttestationLags)
+	}
+
+	p := c.MapToChainParams()
+	if p.DalNumberOfSlots != 160 || p.DalSlotSize != 380832 || p.DalAttestationLag != 5 {
+		t.Errorf("DAL params not surfaced: slots=%d size=%d lag=%d", p.DalNumberOfSlots, p.DalSlotSize, p.DalAttestationLag)
+	}
+	if len(p.DalAttestationLags) != 5 {
+		t.Errorf("DalAttestationLags = %v, want length 5", p.DalAttestationLags)
 	}
 }

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -116,10 +116,10 @@ type Params struct {
 	AllBakersAttestActivationThreshold Ratio `json:"all_bakers_attest_activation_threshold"`
 
 	// data availability layer (v019+, attestation_lags new in v025)
-	DalNumberOfSlots   int64   `json:"dal_number_of_slots,omitempty"`
-	DalSlotSize        int64   `json:"dal_slot_size,omitempty"`
-	DalAttestationLag  int64   `json:"dal_attestation_lag,omitempty"`
-	DalAttestationLags []int64 `json:"dal_attestation_lags,omitempty"`
+	DalNumberOfSlots   int64   `json:"dal_number_of_slots,omitempty"`  // DAL slots per block (v025: 160)
+	DalSlotSize        int64   `json:"dal_slot_size,omitempty"`        // slot size in bytes (v025: 380832)
+	DalAttestationLag  int64   `json:"dal_attestation_lag,omitempty"`  // legacy scalar lag; canonical from v025 is DalAttestationLags
+	DalAttestationLags []int64 `json:"dal_attestation_lags,omitempty"` // allowed dynamic lags, v025+ (e.g. [1,2,3,4,5]); nil before
 
 	// extra features to follow protocol upgrades
 	OperationTagsVersion int   `json:"operation_tags_version,omitempty"` // 1: v5..v11, 2: v12..v18, 3:v19-v22, 4: v23+

--- a/tezos/params.go
+++ b/tezos/params.go
@@ -115,6 +115,12 @@ type Params struct {
 	// feature flags
 	AllBakersAttestActivationThreshold Ratio `json:"all_bakers_attest_activation_threshold"`
 
+	// data availability layer (v019+, attestation_lags new in v025)
+	DalNumberOfSlots   int64   `json:"dal_number_of_slots,omitempty"`
+	DalSlotSize        int64   `json:"dal_slot_size,omitempty"`
+	DalAttestationLag  int64   `json:"dal_attestation_lag,omitempty"`
+	DalAttestationLags []int64 `json:"dal_attestation_lags,omitempty"`
+
 	// extra features to follow protocol upgrades
 	OperationTagsVersion int   `json:"operation_tags_version,omitempty"` // 1: v5..v11, 2: v12..v18, 3:v19-v22, 4: v23+
 	StartHeight          int64 `json:"start_height"`                     // protocol start (may be != cycle start!!)


### PR DESCRIPTION
## Summary

Item **4** of BIN-878 — decode the new/changed v025 (Ushuaia) protocol constants instead of silently dropping them.

- **`Constants.Dal`** (`dal_parametric`) — new `DalParametric` struct decoding `feature_enable`, `number_of_slots` (→160), `slot_size` (→380832), `page_size`, `number_of_shards`, `redundancy_factor`, `attestation_lag` (→5), `attestation_threshold`, and the new **`attestation_lags`** dynamic-lag list.
- **`Constants.CacheLayoutSize`** (`cache_layout_size`, 3 → 5).
- **`tezos.Params`** — added `DalNumberOfSlots`, `DalSlotSize`, `DalAttestationLag`, `DalAttestationLags`; `MapToChainParams` surfaces them (guarded so older protocols without DAL constants are unaffected).

## Intentionally not surfaced

`cache_stake_info_cycles` and `cache_swrr_selected_distribution_cycles` are internal caching constants TzGo doesn't expose — left out per the "add only what we surface" guidance. Custom structs via `GetCustomConstants` can still read them.

## Tests

- `TestConstantsV025Dal`: decodes a v025-style constants blob and asserts both the `DalParametric` decode and the `MapToChainParams` surfacing.
- `go test ./rpc/ ./tezos/` green; `go vet` clean.

Part of BIN-878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)