### PR TITLE
tezos: add tz5 (ML-DSA-44) address support, PKH only [BIN-923]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Fixed `WithProtocol` to assign `OperationTagsVersion = 4` for protocols v023+ (was capped at 3); tag encoding is unchanged (v2+ tag table)
 * Deployment rows and `DefaultParams`/`GhostnetParams`/`ShadownetParams` repointing deferred until activation heights are published
 
+#### tz5 Addresses (ML-DSA-44, PKH only)
+* Added `AddressTypeMlDsa44` (tz5): base58 parse/format, 21-byte tag-4 and 22-byte padded binary encode/decode, usable as transaction destination. tz5 addresses classify as EOAs via the new `KeyTypeMlDsa44`
+* ML-DSA-44 keys and signatures remain unsupported in this slice — decoding them still fails with explicit errors (Signature V3 support is a follow-up)
+* BREAKING: blinded (btz1) addresses no longer alias internal binary tag 4, which belongs to tz5 on-chain since v025; blinded addresses never legitimately appear in tagged binary form
+
 ## v1.24.0
 
 ### [Tallinn Protocol](https://octez.tezos.com/docs/protocols/024_tallinn.html) Support 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
 * Deployment rows and `DefaultParams`/`GhostnetParams`/`ShadownetParams` repointing deferred until activation heights are published
 
 #### tz5 Addresses (ML-DSA-44, PKH only)
-* Added `AddressTypeMlDsa44` (tz5): base58 parse/format, 21-byte tag-4 and 22-byte padded binary encode/decode, usable as transaction destination. tz5 addresses classify as EOAs via the new `KeyTypeMlDsa44`
-* ML-DSA-44 keys and signatures remain unsupported in this slice — decoding them still fails with explicit errors (Signature V3 support is a follow-up)
-* BREAKING: blinded (btz1) addresses no longer alias internal binary tag 4, which belongs to tz5 on-chain since v025; blinded addresses never legitimately appear in tagged binary form
+* Added `AddressTypeMlDsa44` (tz5): base58 parse/format, 21-byte tag-4 and 22-byte padded binary encode/decode, usable as transaction source and destination. tz5 addresses classify as EOAs via the new `KeyTypeMlDsa44`. Note: tz5 accounts are gated on-chain by the `tz5_account_enable` feature flag (off on mainnet at v025 activation); the SDK recognizes the address type unconditionally
+* ML-DSA-44 keys and signatures remain unsupported in this slice — binary key tag 4 now fails with an explicit "ML-DSA-44 not implemented" error instead of a generic unknown-type error (Signature V3 support is a follow-up)
+* BREAKING: blinded (btz1) addresses no longer alias internal binary tag 4, which belongs to tz5 on-chain since v025; `AddressTypeBlinded.Tag()` now returns 255 (was 4), so binary-encoding a blinded address produces a visibly invalid tag instead of aliasing to tz5. Blinded addresses never legitimately appear in tagged binary form; text (btz1) parsing is unchanged
+* `KeyTypeInvalid`'s numeric value shifted from 4 to 5 (Go API only; wire encodings go through `Tag()`/`ParseKeyTag` and are unaffected)
 
 ## v1.24.0
 

--- a/codec/tz5_test.go
+++ b/codec/tz5_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 TriliTech Ltd.
+// Author: tzstats@trili.tech
+
+package codec
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/trilitech/tzgo/tezos"
+)
+
+// TestTransactionWithTz5Destination verifies that operations referencing a tz5
+// (ML-DSA-44, v025 Ushuaia) address as destination round-trip through binary
+// encode/decode without loss (PKH-only support, BIN-923).
+func TestTransactionWithTz5Destination(t *testing.T) {
+	src := tezos.MustParseAddress("tz1LggX2HUdvJ1tF4Fvv8fjsrzLeW4Jr9t2Q")
+	dst := tezos.MustParseAddress("tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTY")
+	tx := &Transaction{
+		Manager:     Manager{Source: src},
+		Destination: dst,
+		Amount:      tezos.N(1000),
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := tx.EncodeBuffer(buf, tezos.DefaultParams); err != nil {
+		t.Fatalf("encode tx with tz5 destination: %v", err)
+	}
+	enc := append([]byte(nil), buf.Bytes()...)
+
+	tx2 := &Transaction{}
+	if err := tx2.DecodeBuffer(bytes.NewBuffer(enc), tezos.DefaultParams); err != nil {
+		t.Fatalf("decode tx with tz5 destination: %v", err)
+	}
+	if got, want := tx2.Destination.String(), dst.String(); got != want {
+		t.Errorf("destination = %s, want %s", got, want)
+	}
+
+	buf2 := bytes.NewBuffer(nil)
+	if err := tx2.EncodeBuffer(buf2, tezos.DefaultParams); err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	if !bytes.Equal(enc, buf2.Bytes()) {
+		t.Errorf("binary round-trip mismatch:\n enc=%x\n got=%x", enc, buf2.Bytes())
+	}
+}

--- a/codec/tz5_test.go
+++ b/codec/tz5_test.go
@@ -44,3 +44,39 @@ func TestTransactionWithTz5Destination(t *testing.T) {
 		t.Errorf("binary round-trip mismatch:\n enc=%x\n got=%x", enc, buf2.Bytes())
 	}
 }
+
+// TestTransactionWithTz5Source verifies the source side of FR-005: a tz5
+// address in the Manager.Source field round-trips through binary
+// encode/decode. Source-side signing needs ML-DSA keys (out of scope), but
+// the address field encoding itself is key-independent.
+func TestTransactionWithTz5Source(t *testing.T) {
+	src := tezos.MustParseAddress("tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTY")
+	dst := tezos.MustParseAddress("tz1LggX2HUdvJ1tF4Fvv8fjsrzLeW4Jr9t2Q")
+	tx := &Transaction{
+		Manager:     Manager{Source: src},
+		Destination: dst,
+		Amount:      tezos.N(1000),
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := tx.EncodeBuffer(buf, tezos.DefaultParams); err != nil {
+		t.Fatalf("encode tx with tz5 source: %v", err)
+	}
+	enc := append([]byte(nil), buf.Bytes()...)
+
+	tx2 := &Transaction{}
+	if err := tx2.DecodeBuffer(bytes.NewBuffer(enc), tezos.DefaultParams); err != nil {
+		t.Fatalf("decode tx with tz5 source: %v", err)
+	}
+	if got, want := tx2.Source.String(), src.String(); got != want {
+		t.Errorf("source = %s, want %s", got, want)
+	}
+
+	buf2 := bytes.NewBuffer(nil)
+	if err := tx2.EncodeBuffer(buf2, tezos.DefaultParams); err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	if !bytes.Equal(enc, buf2.Bytes()) {
+		t.Errorf("binary round-trip mismatch:\n enc=%x\n got=%x", enc, buf2.Bytes())
+	}
+}

--- a/specs/001-tz5-pkh-support/checklists/requirements.md
+++ b/specs/001-tz5-pkh-support/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: tz5 Address Support (PKH only)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Scope deliberately excludes ML-DSA keys/signatures (follow-up slice of BIN-878
+  item 2); FR-006 pins the explicit-error behaviour for the excluded surface.
+- FR-001/FR-002 reference protocol constants (prefix bytes, tag value) because
+  they are externally mandated wire-format facts, not implementation choices.

--- a/specs/001-tz5-pkh-support/spec.md
+++ b/specs/001-tz5-pkh-support/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: tz5 Address Support (PKH only)
+
+**Feature Branch**: `001-tz5-pkh-support`
+
+**Created**: 2026-06-10
+
+**Status**: Draft
+
+**Input**: User description: "Address item 2 from BIN-878 (v025/Ushuaia cryptography). For now only do the fast win: tz5 PKH support only. Majority of applications will be able to get away with tz5 as PKH only — tx parsing, tx recipients etc."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Parse tz5 addresses from chain data (Priority: P1)
+
+An application reading Tezos blocks, operations, or contract storage encounters a
+tz5 address (a post-quantum ML-DSA-44 account introduced in protocol v025) as a
+sender, recipient, delegate, or stored value. The SDK recognises the address in
+both its text form (`tz5…`) and its on-chain binary form, and surfaces it as a
+normal typed address — exactly as it does today for tz1/tz2/tz3/tz4.
+
+**Why this priority**: Without this, reading any block or operation that touches a
+tz5 account fails or silently mis-decodes. This is the breaking exposure named in
+BIN-878 and blocks indexers and wallets the moment the feature flag activates on
+any network.
+
+**Independent Test**: Feed the SDK a tz5 address string and the equivalent binary
+encodings; verify both decode to the same typed address and re-encode to the exact
+original bytes/string.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid `tz5…` address string, **When** the application parses it,
+   **Then** it gets a valid address whose type identifies the new account kind and
+   whose text form round-trips to the identical string.
+2. **Given** a 21-byte binary implicit address with the new on-chain tag (4),
+   **When** the application decodes it, **Then** it gets the same address as the
+   text form, and re-encoding produces the identical 21 bytes.
+3. **Given** a 22-byte padded binary address (as found in contract storage),
+   **When** decoded, **Then** the same address results.
+4. **Given** an invalid tz5 string (wrong checksum or length), **When** parsed,
+   **Then** the application receives an explicit error, never a wrong address.
+
+---
+
+### User Story 2 - Use tz5 addresses as transaction recipients (Priority: P2)
+
+A wallet or service constructs a transaction whose destination is a tz5 address.
+The SDK encodes the destination correctly so a Tezos node accepts the operation.
+
+**Why this priority**: Sending funds *to* tz5 accounts is the most common
+interaction ordinary applications will have with post-quantum accounts; it does
+not require any new cryptography on the sender side.
+
+**Independent Test**: Build a transaction with a tz5 destination and verify the
+binary encoding matches the protocol's expected destination bytes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction whose destination is a tz5 address, **When** the
+   operation is serialized, **Then** the destination field contains the correct
+   tagged binary form and the operation round-trips decode→encode unchanged.
+2. **Given** a tz5 address used where an entity classification is needed,
+   **When** the application asks "is this an implicit (externally-owned)
+   account?", **Then** the answer is yes.
+
+---
+
+### Edge Cases
+
+- A blinded (btz1) address previously shared the internal tag slot now assigned
+  on-chain to tz5. Binary encoding of blinded addresses must not be confusable
+  with tz5; blinded addresses never legitimately appear in tagged binary form, so
+  they must now fail loudly rather than alias to tz5.
+- ML-DSA public keys, secret keys, and signatures are **out of scope**; if chain
+  data contains an ML-DSA public key or signature (e.g. a tz5 reveal), the SDK
+  must return an explicit "unsupported" error rather than mis-parse — matching
+  current behaviour for unknown key tags.
+- Addresses with entrypoint suffixes (`tz5…%ep`) must parse like other types.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SDK MUST parse base58 `tz5…` strings (prefix bytes 6,161,169;
+  20-byte hash; 36-char encoding) into a typed address, and format that address
+  back to the identical string.
+- **FR-002**: The SDK MUST decode 21-byte tagged binary implicit addresses with
+  tag 4 as tz5 addresses, and encode tz5 addresses to that exact binary form;
+  the 22-byte zero-padded variant MUST behave equivalently.
+- **FR-003**: tz5 addresses MUST be classified as implicit (externally-owned)
+  accounts, comparable and usable as map keys like all other address types.
+- **FR-004**: Binary encoding of blinded (btz1) addresses MUST NOT produce the
+  tz5 tag; the previous internal aliasing of tag 4 to blinded MUST be removed.
+- **FR-005**: Operations (e.g. transactions) that reference tz5 addresses as
+  source/destination MUST round-trip through binary encode/decode without loss.
+- **FR-006**: ML-DSA keys and signatures remain unsupported in this slice; any
+  attempt to decode them MUST fail with an explicit error (no silent mis-parse).
+- **FR-007**: Existing behaviour for tz1/tz2/tz3/tz4/KT1/txr1/sr1/btz1 text
+  parsing MUST be unchanged (backward compatibility).
+
+### Assumptions
+
+- The tz5 base58 prefix bytes and the binary tag value are taken from the
+  protocol implementation source (octez `base58.ml`: `"\006\161\169"`;
+  `signature_v3.ml`: PKH union Tag 4) — both verified, not guessed.
+- Full ML-DSA-44 support (keys, signatures, reveal proofs, signing) is a
+  follow-up slice of BIN-878 item 2 and intentionally excluded here.
+- tz5 accounts are feature-flagged off on mainnet at v025 activation, so this
+  slice carries no immediate mainnet risk while unblocking testnet usage.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: 100% of valid tz5 address strings round-trip parse→format
+  byte-identically, and invalid ones produce explicit errors.
+- **SC-002**: 100% of tagged binary tz5 encodings (21- and 22-byte forms)
+  round-trip decode→encode byte-identically.
+- **SC-003**: Applications can classify tz5 addresses as implicit accounts and
+  use them as transaction recipients with no application-side special-casing.
+- **SC-004**: The full existing test suite continues to pass (no regression for
+  other address types).
+
+## Key Entities
+
+- **tz5 address**: a 20-byte public key hash of an ML-DSA-44 (post-quantum)
+  public key, text-encoded with prefix `tz5`, binary-encoded as implicit-address
+  tag 4. Introduced by protocol v025 (Ushuaia) behind the `tz5_account_enable`
+  feature flag.
+- **Blinded address (btz1)**: commitment-style address that previously occupied
+  the SDK-internal tag slot now used on-chain by tz5; never legitimately appears
+  in tagged binary form.

--- a/tezos/address.go
+++ b/tezos/address.go
@@ -59,6 +59,7 @@ const (
 	AddressTypeBls12_381                      // 6
 	AddressTypeTxRollup                       // 7
 	AddressTypeSmartRollup                    // 8
+	AddressTypeMlDsa44                        // 9, tz5 (v025 Ushuaia)
 )
 
 var (
@@ -68,10 +69,13 @@ var (
 		{2, 1, "secp256k1", HashTypePkhSecp256k1, KeyTypeSecp256k1},
 		{3, 2, "p256", HashTypePkhP256, KeyTypeP256},
 		{4, 255, "contract", HashTypePkhNocurve, KeyTypeInvalid},
-		{5, 4, "blinded", HashTypePkhBlinded, KeyTypeInvalid},
+		// Note: blinded addresses never appear in tagged binary form; their
+		// former internal tag 4 is used on-chain by ML-DSA-44 (tz5) since v025.
+		{5, 255, "blinded", HashTypePkhBlinded, KeyTypeInvalid},
 		{6, 3, "bls12_381", HashTypePkhBls12_381, KeyTypeBls12_381},
 		{7, 255, "tx_rollup", HashTypeTxRollupAddress, KeyTypeInvalid},
 		{8, 255, "smart_rollup", HashTypeSmartRollupAddress, KeyTypeInvalid},
+		{9, 4, "mldsa44", HashTypePkhMlDsa44, KeyTypeMlDsa44},
 	}
 
 	addressTags = []AddressType{
@@ -79,7 +83,7 @@ var (
 		AddressTypeSecp256k1, // 1
 		AddressTypeP256,      // 2
 		AddressTypeBls12_381, // 3
-		AddressTypeBlinded,   // 4, can be anything actually as it is never supposed to have a tag
+		AddressTypeMlDsa44,   // 4, tz5 since v025 (Ushuaia)
 	}
 )
 

--- a/tezos/address.go
+++ b/tezos/address.go
@@ -59,7 +59,13 @@ const (
 	AddressTypeBls12_381                      // 6
 	AddressTypeTxRollup                       // 7
 	AddressTypeSmartRollup                    // 8
-	AddressTypeMlDsa44                        // 9, tz5 (v025 Ushuaia)
+	// AddressTypeMlDsa44 is the tz5 ML-DSA-44 (post-quantum) account type
+	// introduced in protocol v025 (Ushuaia). PKH-only: key material and
+	// signatures are not implemented. tz5 accounts are gated on-chain by the
+	// tz5_account_enable feature flag (off on mainnet at activation); the SDK
+	// recognizes the address type unconditionally because the same code path
+	// decodes data from networks where the flag is enabled.
+	AddressTypeMlDsa44 // 9, tz5 (v025 Ushuaia)
 )
 
 var (

--- a/tezos/address_test.go
+++ b/tezos/address_test.go
@@ -59,14 +59,6 @@ func TestAddress(t *testing.T) {
 			Bytes:   "015c149d65c5ca113bc2bc3c861ef6ea8030d7155300",
 			Padded:  "015c149d65c5ca113bc2bc3c861ef6ea8030d7155300",
 		},
-		// btz1
-		{
-			Address: "btz1LKs15uHQ4PgCoY3ZDq55CKJ5wDq9jQwfk",
-			Hash:    "000b80d92ce17aa6070fde1a99288a4213a5b650",
-			Type:    AddressTypeBlinded,
-			Bytes:   "04000b80d92ce17aa6070fde1a99288a4213a5b650",
-			Padded:  "0004000b80d92ce17aa6070fde1a99288a4213a5b650",
-		},
 		// TODO: AddressTypeSapling
 		// tz4
 		{
@@ -75,6 +67,14 @@ func TestAddress(t *testing.T) {
 			Type:    AddressTypeBls12_381,
 			Bytes:   "035d1497f39b87599983fe8f29599b679564be822d",
 			Padded:  "00035d1497f39b87599983fe8f29599b679564be822d",
+		},
+		// tz5 (v025 Ushuaia, ML-DSA-44 PKH only)
+		{
+			Address: "tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTY",
+			Hash:    "5d1497f39b87599983fe8f29599b679564be822d",
+			Type:    AddressTypeMlDsa44,
+			Bytes:   "045d1497f39b87599983fe8f29599b679564be822d",
+			Padded:  "00045d1497f39b87599983fe8f29599b679564be822d",
 		},
 		// txr1
 		{
@@ -231,5 +231,59 @@ func BenchmarkAddressEncode(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = a.String()
+	}
+}
+
+// TestMlDsa44Address verifies tz5 (v025 Ushuaia) PKH-only semantics: implicit
+// account classification and binary tag 4 ownership.
+func TestMlDsa44Address(t *testing.T) {
+	a, err := ParseAddress("tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTY")
+	if err != nil {
+		t.Fatalf("parse tz5: %v", err)
+	}
+	if !a.IsEOA() {
+		t.Errorf("tz5 address must classify as EOA")
+	}
+	if a.IsContract() || a.IsRollup() {
+		t.Errorf("tz5 address must not classify as contract or rollup")
+	}
+	if got := a.KeyType(); got != KeyTypeMlDsa44 {
+		t.Errorf("tz5 KeyType = %v, want KeyTypeMlDsa44", got)
+	}
+	// ML-DSA key material is unsupported in the PKH-only slice
+	if KeyTypeMlDsa44.PkHashType().Len != 0 || KeyTypeMlDsa44.PkPrefixBytes() != nil {
+		t.Errorf("ML-DSA pk decoding must remain unsupported")
+	}
+	if DetectAddressType("tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTY") != AddressTypeMlDsa44 {
+		t.Errorf("DetectAddressType must recognize tz5")
+	}
+}
+
+// TestBlindedAddressNoBinaryTag verifies that blinded (btz1) addresses no longer
+// alias on-chain binary tag 4, which belongs to ML-DSA-44 (tz5) since v025.
+// Text parsing of btz1 addresses is unchanged.
+func TestBlindedAddressNoBinaryTag(t *testing.T) {
+	a, err := ParseAddress("btz1LKs15uHQ4PgCoY3ZDq55CKJ5wDq9jQwfk")
+	if err != nil {
+		t.Fatalf("parse btz1: %v", err)
+	}
+	if got, want := a.Type(), AddressTypeBlinded; got != want {
+		t.Fatalf("type = %v, want %v", got, want)
+	}
+	if got, want := a.String(), "btz1LKs15uHQ4PgCoY3ZDq55CKJ5wDq9jQwfk"; got != want {
+		t.Errorf("text round-trip = %s, want %s", got, want)
+	}
+	// binary encoding must not emit tag 4 anymore
+	if enc := a.Encode(); len(enc) > 0 && enc[0] == 4 {
+		t.Errorf("blinded address must not binary-encode with tag 4 (tz5)")
+	}
+	// tag 4 binary decodes as tz5, not blinded
+	var b Address
+	buf := MustDecodeString("045d1497f39b87599983fe8f29599b679564be822d")
+	if err := b.Decode(buf); err != nil {
+		t.Fatalf("decode tag 4: %v", err)
+	}
+	if got, want := b.Type(), AddressTypeMlDsa44; got != want {
+		t.Errorf("tag 4 decodes as %v, want %v", got, want)
 	}
 }

--- a/tezos/address_test.go
+++ b/tezos/address_test.go
@@ -6,6 +6,7 @@ package tezos
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 )
 
@@ -257,6 +258,22 @@ func TestMlDsa44Address(t *testing.T) {
 	if DetectAddressType("tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTY") != AddressTypeMlDsa44 {
 		t.Errorf("DetectAddressType must recognize tz5")
 	}
+
+	// malformed inputs must fail explicitly
+	if _, err := ParseAddress("tz5VWE3unqGsLVrYhxCGBxiVVYXDjHHbmbTZ"); err == nil {
+		t.Errorf("expected checksum error on corrupted tz5 string")
+	}
+	if _, err := ParseAddress("tz5VWE3unq"); err == nil {
+		t.Errorf("expected error on truncated tz5 string")
+	}
+
+	// binary ML-DSA public keys (tag 4) remain unsupported with an explicit error
+	var k Key
+	buf := append([]byte{4}, make([]byte, 32)...)
+	err = k.UnmarshalBinary(buf)
+	if err == nil || !strings.Contains(err.Error(), "ML-DSA-44") {
+		t.Errorf("binary key tag 4 must fail with explicit unsupported error, got %v", err)
+	}
 }
 
 // TestBlindedAddressNoBinaryTag verifies that blinded (btz1) addresses no longer
@@ -269,6 +286,11 @@ func TestBlindedAddressNoBinaryTag(t *testing.T) {
 	}
 	if got, want := a.Type(), AddressTypeBlinded; got != want {
 		t.Fatalf("type = %v, want %v", got, want)
+	}
+	// hash check preserved from the former TestAddress table entry; only the
+	// binary tag round-trip is intentionally no longer supported since v025
+	if want := MustDecodeString("000b80d92ce17aa6070fde1a99288a4213a5b650"); !bytes.Equal(a[1:], want) {
+		t.Errorf("hash = %x, want %x", a[1:], want)
 	}
 	if got, want := a.String(), "btz1LKs15uHQ4PgCoY3ZDq55CKJ5wDq9jQwfk"; got != want {
 		t.Errorf("text round-trip = %s, want %s", got, want)

--- a/tezos/hash.go
+++ b/tezos/hash.go
@@ -100,7 +100,8 @@ var (
 	HashTypeSmartRollupCommitHash     = HashType{SMART_ROLLUP_COMMITMENT_HASH_ID, 32, SMART_ROLLUP_COMMITMENT_HASH_PREFIX, 54}
 	HashTypeSmartRollupRevealHash     = HashType{SMART_ROLLUP_REVEAL_HASH_ID, 32, SMART_ROLLUP_REVEAL_HASH_PREFIX, 56}
 
-	// v025 Ushuaia, ML-DSA-44 (PKH only)
+	// HashTypePkhMlDsa44 is the tz5 public key hash type for ML-DSA-44
+	// accounts (v025 Ushuaia, PKH only): 20-byte hash, 36-char base58.
 	HashTypePkhMlDsa44 = HashType{MLDSA44_PUBLIC_KEY_HASH_ID, 20, MLDSA44_PUBLIC_KEY_HASH_PREFIX, 36}
 )
 

--- a/tezos/hash.go
+++ b/tezos/hash.go
@@ -99,6 +99,9 @@ var (
 	HashTypeSmartRollupStateHash      = HashType{SMART_ROLLUP_STATE_HASH_ID, 32, SMART_ROLLUP_STATE_HASH_PREFIX, 54}
 	HashTypeSmartRollupCommitHash     = HashType{SMART_ROLLUP_COMMITMENT_HASH_ID, 32, SMART_ROLLUP_COMMITMENT_HASH_PREFIX, 54}
 	HashTypeSmartRollupRevealHash     = HashType{SMART_ROLLUP_REVEAL_HASH_ID, 32, SMART_ROLLUP_REVEAL_HASH_PREFIX, 56}
+
+	// v025 Ushuaia, ML-DSA-44 (PKH only)
+	HashTypePkhMlDsa44 = HashType{MLDSA44_PUBLIC_KEY_HASH_ID, 20, MLDSA44_PUBLIC_KEY_HASH_PREFIX, 36}
 )
 
 func (t HashType) IsValid() bool {

--- a/tezos/key.go
+++ b/tezos/key.go
@@ -594,7 +594,7 @@ func (k PrivateKey) Public() Key {
 			pk.Type = KeyTypeInvalid
 			return pk
 		}
-		pk.Data = elliptic.MarshalCompressed(curve, ecKey.PublicKey.X, ecKey.PublicKey.Y)
+		pk.Data = elliptic.MarshalCompressed(curve, ecKey.X, ecKey.Y)
 	case KeyTypeBls12_381:
 		// TODO
 	}

--- a/tezos/key.go
+++ b/tezos/key.go
@@ -46,6 +46,11 @@ const (
 	KeyTypeSecp256k1
 	KeyTypeP256
 	KeyTypeBls12_381
+	// KeyTypeMlDsa44 identifies ML-DSA-44 (post-quantum) accounts introduced in
+	// v025 (Ushuaia). Only the address (tz5 PKH) side is supported; ML-DSA key
+	// material and signatures are not implemented yet, so all key operations on
+	// this type return invalid/unsupported results.
+	KeyTypeMlDsa44
 	KeyTypeInvalid
 )
 
@@ -108,6 +113,8 @@ func (t KeyType) AddressType() AddressType {
 		return AddressTypeP256
 	case KeyTypeBls12_381:
 		return AddressTypeBls12_381
+	case KeyTypeMlDsa44:
+		return AddressTypeMlDsa44
 	default:
 		return AddressTypeInvalid
 	}

--- a/tezos/key.go
+++ b/tezos/key.go
@@ -49,7 +49,10 @@ const (
 	// KeyTypeMlDsa44 identifies ML-DSA-44 (post-quantum) accounts introduced in
 	// v025 (Ushuaia). Only the address (tz5 PKH) side is supported; ML-DSA key
 	// material and signatures are not implemented yet, so all key operations on
-	// this type return invalid/unsupported results.
+	// this type return invalid/unsupported results (explicit per-switch cases
+	// below). Note: inserting this constant shifted KeyTypeInvalid's numeric
+	// value from 4 to 5; this is a Go-API-only change — wire encodings always
+	// go through Tag()/ParseKeyTag and are unaffected.
 	KeyTypeMlDsa44
 	KeyTypeInvalid
 )
@@ -68,6 +71,9 @@ func (t KeyType) Curve() elliptic.Curve {
 		return secp256k1.S256()
 	case KeyTypeP256:
 		return elliptic.P256()
+	case KeyTypeMlDsa44:
+		// PKH-only: ML-DSA-44 is not an elliptic curve scheme
+		return nil
 	default:
 		return nil
 	}
@@ -83,6 +89,9 @@ func (t KeyType) PkHashType() HashType {
 		return HashTypePkP256
 	case KeyTypeBls12_381:
 		return HashTypePkBls12_381
+	case KeyTypeMlDsa44:
+		// PKH-only: ML-DSA key material is not supported yet
+		return HashTypeInvalid
 	default:
 		return HashTypeInvalid
 	}
@@ -98,6 +107,9 @@ func (t KeyType) SkHashType() HashType {
 		return HashTypeSkP256
 	case KeyTypeBls12_381:
 		return HashTypeSkBls12_381
+	case KeyTypeMlDsa44:
+		// PKH-only: ML-DSA key material is not supported yet
+		return HashTypeInvalid
 	default:
 		return HashTypeInvalid
 	}
@@ -130,6 +142,9 @@ func (t KeyType) PkPrefixBytes() []byte {
 		return P256_PUBLIC_KEY_ID
 	case KeyTypeBls12_381:
 		return BLS12_381_PUBLIC_KEY_ID
+	case KeyTypeMlDsa44:
+		// PKH-only: mdpk parsing is not supported yet
+		return nil
 	default:
 		return nil
 	}
@@ -145,6 +160,9 @@ func (t KeyType) PkPrefix() string {
 		return P256_PUBLIC_KEY_PREFIX
 	case KeyTypeBls12_381:
 		return BLS12_381_PUBLIC_KEY_PREFIX
+	case KeyTypeMlDsa44:
+		// PKH-only: mdpk parsing is not supported yet
+		return ""
 	default:
 		return ""
 	}
@@ -160,6 +178,9 @@ func (t KeyType) SkPrefixBytes() []byte {
 		return P256_SECRET_KEY_ID
 	case KeyTypeBls12_381:
 		return BLS12_381_SECRET_KEY_ID
+	case KeyTypeMlDsa44:
+		// PKH-only: mdsk parsing is not supported yet
+		return nil
 	default:
 		return nil
 	}
@@ -175,6 +196,9 @@ func (t KeyType) SkePrefixBytes() []byte {
 		return P256_ENCRYPTED_SECRET_KEY_ID
 	case KeyTypeBls12_381:
 		return BLS12_381_SECRET_KEY_ID
+	case KeyTypeMlDsa44:
+		// PKH-only: mdesk parsing is not supported yet
+		return nil
 	default:
 		return nil
 	}
@@ -190,6 +214,9 @@ func (t KeyType) SkPrefix() string {
 		return P256_SECRET_KEY_PREFIX
 	case KeyTypeBls12_381:
 		return BLS12_381_SECRET_KEY_PREFIX
+	case KeyTypeMlDsa44:
+		// PKH-only: mdsk parsing is not supported yet
+		return ""
 	default:
 		return ""
 	}
@@ -205,6 +232,9 @@ func (t KeyType) SkePrefix() string {
 		return P256_ENCRYPTED_SECRET_KEY_PREFIX
 	case KeyTypeBls12_381:
 		return BLS12_381_ENCRYPTED_SECRET_KEY_PREFIX
+	case KeyTypeMlDsa44:
+		// PKH-only: mdesk parsing is not supported yet
+		return ""
 	default:
 		return ""
 	}
@@ -220,11 +250,21 @@ func (t KeyType) Tag() byte {
 		return 2
 	case KeyTypeBls12_381:
 		return 3
+	case KeyTypeMlDsa44:
+		// The on-wire public key tag for ML-DSA-44 is 4 (signature_v3), but
+		// it is intentionally unmapped while key material is unsupported so
+		// an accidental encode produces a visibly invalid tag instead of a
+		// well-formed blob with arbitrary data. Map this when Signature V3
+		// support lands.
+		return 255
 	default:
 		return 255
 	}
 }
 
+// ParseKeyTag maps a binary public key tag to its KeyType. Tag 4 (ML-DSA-44,
+// v025 Ushuaia) is intentionally unmapped while key material is unsupported;
+// binary key decoders return an explicit unsupported error for it.
 func ParseKeyTag(b byte) KeyType {
 	switch b {
 	case 0:
@@ -426,9 +466,13 @@ func (k *Key) UnmarshalBinary(b []byte) error {
 		k.Type = KeyTypeInvalid
 		return nil
 	}
-	// check data size
+	// check data size; tz1/tz2/tz3 keys are 32-33 bytes, tz4 (BLS) is 48;
+	// tz5 (ML-DSA-44) will be 1312 bytes when key support lands
 	if l < 33 {
 		return fmt.Errorf("tezos: invalid binary key length %d", l)
+	}
+	if b[0] == 4 {
+		return fmt.Errorf("tezos: unsupported binary key type 4 (ML-DSA-44 not implemented)")
 	}
 	if typ := ParseKeyTag(b[0]); !typ.IsValid() {
 		return fmt.Errorf("tezos: invalid binary key type %x", b[0])
@@ -450,10 +494,15 @@ func (k *Key) EncodeBuffer(buf *bytes.Buffer) error {
 }
 
 func (k *Key) DecodeBuffer(buf *bytes.Buffer) error {
+	// tz1/tz2/tz3 keys are 32-33 bytes, tz4 (BLS) is 48; tz5 (ML-DSA-44)
+	// will be 1312 bytes when key support lands
 	if l := buf.Len(); l < 33 {
 		return fmt.Errorf("tezos: invalid binary key length %d", l)
 	}
 	tag := buf.Next(1)[0]
+	if tag == 4 {
+		return fmt.Errorf("tezos: unsupported binary key type 4 (ML-DSA-44 not implemented)")
+	}
 	if typ := ParseKeyTag(tag); !typ.IsValid() {
 		return fmt.Errorf("tezos: invalid binary key type %x", tag)
 	} else {

--- a/tezos/magic.go
+++ b/tezos/magic.go
@@ -86,7 +86,8 @@ const (
 	SMART_ROLLUP_COMMITMENT_HASH_PREFIX       = "src1"
 	SMART_ROLLUP_REVEAL_HASH_PREFIX           = "scrrh1"
 
-	// base58 prefix for ML-DSA-44 magics (v025 Ushuaia, PKH only)
+	// MLDSA44_PUBLIC_KEY_HASH_PREFIX is the base58 prefix of ML-DSA-44
+	// public key hashes (v025 Ushuaia, PKH only).
 	MLDSA44_PUBLIC_KEY_HASH_PREFIX = "tz5"
 )
 
@@ -171,6 +172,7 @@ var (
 	SMART_ROLLUP_COMMITMENT_HASH_ID       = []byte{17, 165, 134, 138}       // "\017\165\134\138" (* src1(54) *)
 	SMART_ROLLUP_REVEAL_HASH_ID           = []byte{230, 206, 128, 200, 196} // "\230\206\128\200\196" scrrh1(56)
 
-	// ML-DSA-44 hash magics (v025 Ushuaia, PKH only)
+	// MLDSA44_PUBLIC_KEY_HASH_ID is the base58 version prefix of ML-DSA-44
+	// public key hashes (v025 Ushuaia, PKH only).
 	MLDSA44_PUBLIC_KEY_HASH_ID = []byte{6, 161, 169} // "\006\161\169" tz5(36) 20
 )

--- a/tezos/magic.go
+++ b/tezos/magic.go
@@ -85,6 +85,9 @@ const (
 	SMART_ROLLUP_STATE_HASH_PREFIX            = "srs1"
 	SMART_ROLLUP_COMMITMENT_HASH_PREFIX       = "src1"
 	SMART_ROLLUP_REVEAL_HASH_PREFIX           = "scrrh1"
+
+	// base58 prefix for ML-DSA-44 magics (v025 Ushuaia, PKH only)
+	MLDSA44_PUBLIC_KEY_HASH_PREFIX = "tz5"
 )
 
 var (
@@ -167,4 +170,7 @@ var (
 	SMART_ROLLUP_STATE_HASH_ID            = []byte{17, 165, 235, 240}       // "\017\165\235\240" srs1(54)
 	SMART_ROLLUP_COMMITMENT_HASH_ID       = []byte{17, 165, 134, 138}       // "\017\165\134\138" (* src1(54) *)
 	SMART_ROLLUP_REVEAL_HASH_ID           = []byte{230, 206, 128, 200, 196} // "\230\206\128\200\196" scrrh1(56)
+
+	// ML-DSA-44 hash magics (v025 Ushuaia, PKH only)
+	MLDSA44_PUBLIC_KEY_HASH_ID = []byte{6, 161, 169} // "\006\161\169" tz5(36) 20
 )


### PR DESCRIPTION
## Summary

First slice of BIN-878 (v025 Ushuaia cryptography) —  **tz5 as PKH only**. Applications can parse chain data containing tz5 accounts and use tz5 addresses as transaction recipients, without any ML-DSA cryptography.

Spec: `specs/001-tz5-pkh-support/spec.md` (added in this PR).

## Protocol constants — verified, not guessed

| Constant | Value | Source |
|----------|-------|--------|
| tz5 base58 prefix | `{6, 161, 169}` (20-byte hash, 36 chars) | octez `src/lib_crypto/base58.ml` |
| PKH binary union tag | `4` (Ed25519=0, Secp256k1=1, P256=2, Bls=3, **Mldsa44=4**) | octez `src/lib_crypto/signature_v3.ml` |

## Changes

- **`tezos/address.go`** — `AddressTypeMlDsa44` appended to the enum (existing values stable); registered in `addressTypes` (tag 4, `HashTypePkhMlDsa44`, `KeyTypeMlDsa44`) and `addressTags[4]`.
- **`tezos/magic.go` / `tezos/hash.go`** — `MLDSA44_PUBLIC_KEY_HASH_PREFIX`/`_ID`, `HashTypePkhMlDsa44`.
- **`tezos/key.go`** — `KeyTypeMlDsa44` stub so `Address.IsEOA()` is true for tz5. All key operations return unsupported/invalid; `ParseKeyTag` deliberately unchanged so ML-DSA public keys still fail with explicit errors (no silent mis-parse).
- **⚠️ BREAKING — blinded (btz1) tag 4 aliasing removed**: `addressTags[4]` previously mapped to `AddressTypeBlinded` (its own comment noted it "is never supposed to have a tag"). On-chain tag 4 belongs to Mldsa44 since v025, so a blinded address could otherwise binary-encode as a tz5. Blinded text parsing is unchanged; only the never-legitimate tagged binary form is affected.

## Out of scope (follow-up slices of item 2)

ML-DSA-44 public/secret keys, signatures (~2420 bytes), Signature V3 generic decode, reveal proofs (`codec/reveal.go`), and signing.

## Tests

- `TestAddress` extended with a tz5 case (b58 + 21/22-byte binary round-trips).
- `TestMlDsa44Address`: EOA classification, KeyType mapping, unsupported-key invariants.
- `TestBlindedAddressNoBinaryTag`: btz1 text round-trip unchanged; tag 4 decodes as tz5, blinded no longer emits it.
- `codec/tz5_test.go`: transaction with tz5 destination round-trips byte-identically.
- `go vet` clean, `gofmt -s` clean, full suite green.

Part of BIN-878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)