### PR TITLE
ci: fix golangci-lint v2 config and resolve all lint findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # let every Go version report its own result instead of cancelling
+      # the whole matrix on the first failure
+      fail-fast: false
       matrix:
         go-version: [ '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25' ]
 
@@ -31,7 +34,8 @@ jobs:
         if: matrix.go-version >= '1.22'
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # pinned so lint results do not drift when new linter versions release
+          version: v2.12.2
         env:
           CGO_ENABLED: ${{ matrix.go-version < '1.22' && '0' || '' }}
       - name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,15 +20,15 @@ linters:
       - legacy
       - std-error-handling
     paths:
-      - third_party$
-      - builtin$
-      - examples$
+      - ^third_party/
+      - ^builtin/
+      - ^examples/
 formatters:
   enable:
     - gofmt
   exclusions:
     generated: lax
     paths:
-      - third_party$
-      - builtin$
-      - examples$
+      - ^third_party/
+      - ^builtin/
+      - ^examples/

--- a/cmd/tzgenesis/main.go
+++ b/cmd/tzgenesis/main.go
@@ -38,7 +38,7 @@ func run() error {
 
 	ts, err := time.Parse(time.RFC3339, tm)
 	if err != nil {
-		return fmt.Errorf("Parsing timestamp %q: %v", tm, err)
+		return fmt.Errorf("parsing timestamp %q: %v", tm, err)
 	}
 
 	genesis := Genesis{

--- a/codec/dal_publish.go
+++ b/codec/dal_publish.go
@@ -30,7 +30,7 @@ func (o DalPublishCommitment) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"slot_header":{`)
 	buf.WriteString(`"level":`)
 	buf.WriteString(strconv.Itoa(int(o.Level)))

--- a/codec/delegation.go
+++ b/codec/delegation.go
@@ -26,7 +26,7 @@ func (o Delegation) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	if o.Delegate.IsValid() {
 		buf.WriteString(`,"delegate":`)
 		buf.WriteString(strconv.Quote(o.Delegate.String()))

--- a/codec/deposits_limit.go
+++ b/codec/deposits_limit.go
@@ -26,7 +26,7 @@ func (o SetDepositsLimit) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	if o.Limit != nil {
 		buf.WriteString(`,"limit":`)
 		buf.WriteString(strconv.Quote(o.Limit.String()))

--- a/codec/global_constant.go
+++ b/codec/global_constant.go
@@ -28,7 +28,7 @@ func (o RegisterGlobalConstant) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"value":`)
 	b, _ := o.Value.MarshalJSON()
 	buf.Write(b)

--- a/codec/increase_paid_storage.go
+++ b/codec/increase_paid_storage.go
@@ -27,7 +27,7 @@ func (o IncreasePaidStorage) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"amount":`)
 	buf.WriteString(strconv.Quote(o.Amount.String()))
 	buf.WriteString(`,"destination":`)

--- a/codec/origination.go
+++ b/codec/origination.go
@@ -29,7 +29,7 @@ func (o Origination) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"balance":`)
 	buf.WriteString(strconv.Quote(o.Balance.String()))
 	if o.Delegate.IsValid() {

--- a/codec/reveal.go
+++ b/codec/reveal.go
@@ -29,7 +29,7 @@ func (o Reveal) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"public_key":`)
 	buf.WriteString(strconv.Quote(o.PublicKey.String()))
 	if o.PublicKey.Type == tezos.KeyTypeBls12_381 && o.Proof.Data != nil {

--- a/codec/smart_rollup_add_messages.go
+++ b/codec/smart_rollup_add_messages.go
@@ -27,7 +27,7 @@ func (o SmartRollupAddMessages) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"messages":[`)
 	if len(o.Messages) > 0 {
 		buf.WriteString(strconv.Quote(o.Messages[0].String()))

--- a/codec/smart_rollup_cement.go
+++ b/codec/smart_rollup_cement.go
@@ -26,7 +26,7 @@ func (o SmartRollupCement) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"rollup":`)
 	buf.WriteString(strconv.Quote(o.Rollup.String()))
 	buf.WriteByte('}')

--- a/codec/smart_rollup_originate.go
+++ b/codec/smart_rollup_originate.go
@@ -32,7 +32,7 @@ func (o SmartRollupOriginate) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"pvm_kind":`)
 	buf.WriteString(strconv.Quote(o.Pvm.String()))
 	buf.WriteString(`,"kernel":`)
@@ -66,7 +66,7 @@ func (o *SmartRollupOriginate) DecodeBuffer(buf *bytes.Buffer, p *tezos.Params) 
 	if b, err = readByte(buf.Next(1)); err != nil {
 		return
 	} else if typ := tezos.PvmKind(b); !typ.IsValid() {
-		err = fmt.Errorf("Unsupported PVM type %d", b)
+		err = fmt.Errorf("unsupported PVM type %d", b)
 		return
 	} else {
 		o.Pvm = typ

--- a/codec/smart_rollup_output.go
+++ b/codec/smart_rollup_output.go
@@ -28,7 +28,7 @@ func (o SmartRollupExecuteOutboxMessage) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"rollup":`)
 	buf.WriteString(strconv.Quote(o.Rollup.String()))
 	buf.WriteString(`,"cemented_commitment":`)

--- a/codec/smart_rollup_publish.go
+++ b/codec/smart_rollup_publish.go
@@ -33,7 +33,7 @@ func (o SmartRollupPublish) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"rollup":`)
 	buf.WriteString(strconv.Quote(o.Rollup.String()))
 	buf.WriteString(`,"commitment":{`)

--- a/codec/smart_rollup_recover_bond.go
+++ b/codec/smart_rollup_recover_bond.go
@@ -27,7 +27,7 @@ func (o SmartRollupRecoverBond) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"rollup":`)
 	buf.WriteString(strconv.Quote(o.Rollup.String()))
 	buf.WriteString(`,"staker":`)

--- a/codec/smart_rollup_timeout.go
+++ b/codec/smart_rollup_timeout.go
@@ -30,7 +30,7 @@ func (o SmartRollupTimeout) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"rollup":`)
 	buf.WriteString(strconv.Quote(o.Rollup.String()))
 	buf.WriteString(`,"stakers":{`)

--- a/codec/transaction.go
+++ b/codec/transaction.go
@@ -29,7 +29,7 @@ func (o Transaction) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"amount":`)
 	buf.WriteString(strconv.Quote(o.Amount.String()))
 	buf.WriteString(`,"destination":`)

--- a/codec/transfer_ticket.go
+++ b/codec/transfer_ticket.go
@@ -32,7 +32,7 @@ func (o TransferTicket) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"ticket_contents":`)
 	o.Contents.EncodeJSON(buf)
 	buf.WriteString(`,"ticket_ty":`)

--- a/codec/update_consensus_key.go
+++ b/codec/update_consensus_key.go
@@ -27,7 +27,7 @@ func (o UpdateConsensusKey) MarshalJSON() ([]byte, error) {
 	buf.WriteString(`"kind":`)
 	buf.WriteString(strconv.Quote(o.Kind().String()))
 	buf.WriteByte(',')
-	o.Manager.EncodeJSON(buf)
+	o.EncodeJSON(buf)
 	buf.WriteString(`,"pk":`)
 	buf.WriteString(strconv.Quote(o.PublicKey.String()))
 	buf.WriteByte('}')

--- a/contract/bind/unmarshal.go
+++ b/contract/bind/unmarshal.go
@@ -37,7 +37,7 @@ func UnmarshalPrimPaths(root micheline.Prim, dst map[string]any) error {
 // v must be a non-nil pointer to the expected result.
 func UnmarshalPrim(prim micheline.Prim, v any) error {
 	val := reflect.ValueOf(v)
-	if val.Kind() != reflect.Ptr || val.IsNil() {
+	if val.Kind() != reflect.Pointer || val.IsNil() {
 		return errors.New("v should be a non-nil pointer")
 	}
 
@@ -48,7 +48,7 @@ var _ micheline.PrimUnmarshaler = &Bigmap[string, []byte]{}
 
 func unmarshalPrimVal(prim micheline.Prim, val reflect.Value) error {
 	// Init Elem value if val is Nil
-	if val.Kind() == reflect.Ptr && val.IsNil() {
+	if val.Kind() == reflect.Pointer && val.IsNil() {
 		val.Set(reflect.New(val.Type().Elem()))
 	}
 
@@ -80,7 +80,7 @@ func unmarshalPrimVal(prim micheline.Prim, val reflect.Value) error {
 	}
 
 	// Wasn't handled with *T, try with T
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		return unmarshalPrimVal(prim, val.Elem())
 	}
 
@@ -88,7 +88,7 @@ func unmarshalPrimVal(prim micheline.Prim, val reflect.Value) error {
 }
 
 func unmarshalInt(i *big.Int, v reflect.Value) error {
-	if v.Kind() == reflect.Ptr && v.Type() != tBigInt {
+	if v.Kind() == reflect.Pointer && v.Type() != tBigInt {
 		return unmarshalInt(i, v.Elem())
 	}
 
@@ -105,7 +105,7 @@ func unmarshalInt(i *big.Int, v reflect.Value) error {
 }
 
 func unmarshalString(str string, v reflect.Value) error {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		return unmarshalString(str, v.Elem())
 	}
 
@@ -149,7 +149,7 @@ func unmarshalString(str string, v reflect.Value) error {
 }
 
 func unmarshalBytes(b []byte, v reflect.Value) error {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		return unmarshalBytes(b, v.Elem())
 	}
 
@@ -187,7 +187,7 @@ func unmarshalBytes(b []byte, v reflect.Value) error {
 }
 
 func unmarshalBool(b bool, v reflect.Value) error {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		return unmarshalBool(b, v.Elem())
 	}
 
@@ -201,7 +201,7 @@ func unmarshalBool(b bool, v reflect.Value) error {
 
 // unmarshalSlice unmarshals a Prim sequence, into a slice (through a reflect.Value).
 func unmarshalSlice(prim micheline.Prim, v reflect.Value) error {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		return unmarshalSlice(prim, v.Elem())
 	}
 

--- a/internal/compose/alpha/parse.go
+++ b/internal/compose/alpha/parse.go
@@ -24,7 +24,7 @@ func ParseScript(ctx compose.Context, task Task) (*micheline.Script, error) {
 		script *micheline.Script
 		err    error
 	)
-	if task.Script.ValueSource.IsUsed() {
+	if task.Script.IsUsed() {
 		script, err = loadSource[micheline.Script](ctx, task.Script.ValueSource)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading script")
@@ -34,14 +34,14 @@ func ParseScript(ctx compose.Context, task Task) (*micheline.Script, error) {
 			code  *micheline.Code
 			store *micheline.Prim
 		)
-		if task.Script.Code == nil || !task.Script.Code.ValueSource.IsUsed() {
+		if task.Script.Code == nil || !task.Script.Code.IsUsed() {
 			return nil, fmt.Errorf("missing script code source")
 		}
 		code, err = loadSource[micheline.Code](ctx, task.Script.Code.ValueSource)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading script code")
 		}
-		if task.Script.Storage == nil || (!task.Script.Storage.ValueSource.IsUsed() && task.Script.Storage.Args == nil) {
+		if task.Script.Storage == nil || (!task.Script.Storage.IsUsed() && task.Script.Storage.Args == nil) {
 			return nil, fmt.Errorf("missing initial storage source")
 		}
 		if task.Script.Storage.Args != nil {
@@ -120,7 +120,7 @@ func ParseParams(ctx compose.Context, task Task) (*micheline.Prim, error) {
 		params *micheline.Prim
 		err    error
 	)
-	if task.Params.ValueSource.IsUsed() {
+	if task.Params.IsUsed() {
 		params, err = loadSource[micheline.Prim](ctx, task.Params.ValueSource)
 		if err != nil {
 			return nil, err

--- a/internal/compose/alpha/spec.go
+++ b/internal/compose/alpha/spec.go
@@ -300,7 +300,7 @@ type Storage struct {
 
 func (s Script) Validate(ctx compose.Context) error {
 	// either script-level source or both storage+code sources are required
-	if s.ValueSource.IsUsed() {
+	if s.IsUsed() {
 		if err := s.ValueSource.Validate(ctx); err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ func (s Script) Validate(ctx compose.Context) error {
 		if s.Code == nil {
 			return fmt.Errorf("missing code section")
 		}
-		if err := s.Code.ValueSource.Validate(ctx); err != nil {
+		if err := s.Code.Validate(ctx); err != nil {
 			return err
 		}
 		if s.Storage == nil {
@@ -316,7 +316,7 @@ func (s Script) Validate(ctx compose.Context) error {
 		}
 		if s.Storage.Args == nil {
 			// without args, storage must come from a valid source
-			if err := s.Storage.ValueSource.Validate(ctx); err != nil {
+			if err := s.Storage.Validate(ctx); err != nil {
 				return fmt.Errorf("storage: %v", err)
 			}
 		}

--- a/micheline/entrypoint.go
+++ b/micheline/entrypoint.go
@@ -22,7 +22,7 @@ func (e Entrypoint) Type() Type {
 	}
 	typ := NewType(*e.Prim)
 	if !typ.HasLabel() {
-		typ.Prim.Anno = []string{"@" + e.Name}
+		typ.Anno = []string{"@" + e.Name}
 	}
 	return typ
 }

--- a/micheline/opcodes.go
+++ b/micheline/opcodes.go
@@ -403,7 +403,7 @@ func (op OpCode) MarshalText() ([]byte, error) {
 func ParseOpCode(str string) (OpCode, error) {
 	op, ok := stringToOp[str]
 	if !ok {
-		return 255, fmt.Errorf("Unknown michelson primitive %s", str)
+		return 255, fmt.Errorf("unknown michelson primitive %s", str)
 	}
 	return op, nil
 }

--- a/micheline/primitives.go
+++ b/micheline/primitives.go
@@ -979,9 +979,10 @@ func (p Prim) Value(as OpCode) interface{} {
 	default:
 		switch as {
 		case T_BOOL:
-			if p.OpCode == D_TRUE {
+			switch p.OpCode {
+			case D_TRUE:
 				return true
-			} else if p.OpCode == D_FALSE {
+			case D_FALSE:
 				return false
 			}
 		case T_LAMBDA:

--- a/micheline/primitives_seoul_test.go
+++ b/micheline/primitives_seoul_test.go
@@ -245,17 +245,17 @@ func TestSeoulPrimitivesErrorMessages(t *testing.T) {
 		{
 			name:        "typo in IS_IMPLICIT_ACCOUNT",
 			json:        `{"prim": "IS_IMPLICIT_ACCONT"}`,
-			expectedErr: "Unknown michelson primitive IS_IMPLICIT_ACCONT",
+			expectedErr: "unknown michelson primitive IS_IMPLICIT_ACCONT",
 		},
 		{
 			name:        "lowercase IS_IMPLICIT_ACCOUNT",
 			json:        `{"prim": "is_implicit_account"}`,
-			expectedErr: "Unknown michelson primitive is_implicit_account",
+			expectedErr: "unknown michelson primitive is_implicit_account",
 		},
 		{
 			name:        "partial primitive name",
 			json:        `{"prim": "IS_IMPLICIT"}`,
-			expectedErr: "Unknown michelson primitive IS_IMPLICIT",
+			expectedErr: "unknown michelson primitive IS_IMPLICIT",
 		},
 	}
 

--- a/micheline/translate.go
+++ b/micheline/translate.go
@@ -346,7 +346,7 @@ func walkTree(m map[string]interface{}, label string, typ Type, stack *Stack, lv
 		mm := make(map[string]interface{})
 		switch val.OpCode {
 		case D_LEFT:
-			if !(haveTypeLabel || haveKeyLabel) {
+			if !haveTypeLabel && !haveKeyLabel {
 				mmm := make(map[string]interface{})
 				if err := walkTree(mmm, EMPTY_LABEL, Type{typ.Args[0]}, NewStack(val.Args[0]), lvl+1); err != nil {
 					return err
@@ -370,7 +370,7 @@ func walkTree(m map[string]interface{}, label string, typ Type, stack *Stack, lv
 				}
 			}
 		case D_RIGHT:
-			if !(haveTypeLabel || haveKeyLabel) {
+			if !haveTypeLabel && !haveKeyLabel {
 				mmm := make(map[string]interface{})
 				if err := walkTree(mmm, EMPTY_LABEL, Type{typ.Args[1]}, NewStack(val.Args[0]), lvl+1); err != nil {
 					return err

--- a/micheline/typeinfo.go
+++ b/micheline/typeinfo.go
@@ -85,7 +85,7 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 		// For embedded structs, embed their fields.
 		if f.Anonymous {
 			t := f.Type
-			if t.Kind() == reflect.Ptr {
+			if t.Kind() == reflect.Pointer {
 				t = t.Elem()
 			}
 			if t.Kind() == reflect.Struct {
@@ -247,7 +247,7 @@ func (finfo *fieldInfo) value(v reflect.Value) reflect.Value {
 	for i, x := range finfo.idx {
 		if i > 0 {
 			t := v.Type()
-			if t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct {
+			if t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Struct {
 				if v.IsNil() {
 					v.Set(reflect.New(v.Type().Elem()))
 				}
@@ -263,12 +263,12 @@ func (finfo *fieldInfo) value(v reflect.Value) reflect.Value {
 func derefValue(val reflect.Value) reflect.Value {
 	if val.Kind() == reflect.Interface && !val.IsNil() {
 		e := val.Elem()
-		if e.Kind() == reflect.Ptr && !e.IsNil() {
+		if e.Kind() == reflect.Pointer && !e.IsNil() {
 			val = e
 		}
 	}
 
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			val.Set(reflect.New(val.Type().Elem()))
 		}
@@ -278,7 +278,7 @@ func derefValue(val reflect.Value) reflect.Value {
 }
 
 func indirectType(typ reflect.Type) reflect.Type {
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		val := reflect.New(typ.Elem())
 		return val.Elem().Type()
 	}

--- a/micheline/unmarshal.go
+++ b/micheline/unmarshal.go
@@ -172,7 +172,7 @@ func (p Prim) GetIndexExt(index []int, typ OpCode) (Prim, error) {
 //	Field string  `prim:"-"`
 func (p Prim) Decode(v interface{}) error {
 	val := reflect.ValueOf(v)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		return fmt.Errorf("micheline: non-pointer passed to Decode: %s %s", val.Kind(), val.Type().String())
 	}
 	val = reflect.Indirect(val)
@@ -205,7 +205,7 @@ func (p Prim) unmarshal(val reflect.Value) error {
 		if !dst.IsValid() {
 			continue
 		}
-		if dst.Kind() == reflect.Ptr {
+		if dst.Kind() == reflect.Pointer {
 			if dst.IsNil() && dst.CanSet() {
 				dst.Set(reflect.New(dst.Type()))
 			}
@@ -369,7 +369,7 @@ func (p Prim) unmarshal(val reflect.Value) error {
 			}
 			for idx, ppp := range pp.Args {
 				sval := reflect.New(styp.Elem())
-				if sval.Type().Kind() == reflect.Ptr && sval.IsNil() && sval.CanSet() {
+				if sval.Type().Kind() == reflect.Pointer && sval.IsNil() && sval.CanSet() {
 					sval.Set(reflect.New(sval.Type().Elem()))
 				}
 				// decode from value prim
@@ -407,7 +407,7 @@ func (p Prim) unmarshal(val reflect.Value) error {
 
 				// allocate value
 				mval := reflect.New(mtyp.Elem()).Elem()
-				if mval.Type().Kind() == reflect.Ptr && mval.IsNil() && mval.CanSet() {
+				if mval.Type().Kind() == reflect.Pointer && mval.IsNil() && mval.CanSet() {
 					mval.Set(reflect.New(mval.Type().Elem()))
 				}
 

--- a/rpc/delegation.go
+++ b/rpc/delegation.go
@@ -19,7 +19,7 @@ type Delegation struct {
 // Cost returns operation cost to implement TypedOperation interface.
 func (d Delegation) Costs() tezos.Costs {
 	return tezos.Costs{
-		Fee:     d.Manager.Fee,
+		Fee:     d.Fee,
 		GasUsed: d.Metadata.Result.ConsumedGas,
 	}
 }

--- a/rpc/deposit.go
+++ b/rpc/deposit.go
@@ -30,7 +30,7 @@ func (r SetDepositsLimit) Result() OperationResult {
 // Costs returns operation cost to implement TypedOperation interface.
 func (r SetDepositsLimit) Costs() tezos.Costs {
 	return tezos.Costs{
-		Fee:     r.Manager.Fee,
+		Fee:     r.Fee,
 		GasUsed: r.Metadata.Result.Gas(),
 	}
 }

--- a/rpc/global.go
+++ b/rpc/global.go
@@ -22,7 +22,7 @@ func (c ConstantRegistration) Costs() tezos.Costs {
 	res := c.Metadata.Result
 	burn := res.BalanceUpdates[0].Amount()
 	return tezos.Costs{
-		Fee:         c.Manager.Fee,
+		Fee:         c.Fee,
 		GasUsed:     res.Gas(),
 		Burn:        -burn,
 		StorageUsed: res.StorageSize,

--- a/rpc/increase_storage.go
+++ b/rpc/increase_storage.go
@@ -21,7 +21,7 @@ type IncreasePaidStorage struct {
 func (t IncreasePaidStorage) Costs() tezos.Costs {
 	res := t.Metadata.Result
 	cost := tezos.Costs{
-		Fee:     t.Manager.Fee,
+		Fee:     t.Fee,
 		GasUsed: res.Gas(),
 	}
 	if !t.Result().IsSuccess() {

--- a/rpc/origination.go
+++ b/rpc/origination.go
@@ -34,7 +34,7 @@ func (o Origination) ManagerAddress() tezos.Address {
 func (o Origination) Costs() tezos.Costs {
 	res := o.Metadata.Result
 	cost := tezos.Costs{
-		Fee:         o.Manager.Fee,
+		Fee:         o.Fee,
 		GasUsed:     res.Gas(),
 		StorageUsed: res.PaidStorageSizeDiff,
 	}

--- a/rpc/reveal.go
+++ b/rpc/reveal.go
@@ -19,7 +19,7 @@ type Reveal struct {
 // Costs returns operation cost to implement TypedOperation interface.
 func (r Reveal) Costs() tezos.Costs {
 	return tezos.Costs{
-		Fee:     r.Manager.Fee,
+		Fee:     r.Fee,
 		GasUsed: r.Metadata.Result.Gas(),
 	}
 }

--- a/rpc/smart_rollup.go
+++ b/rpc/smart_rollup.go
@@ -110,7 +110,7 @@ func (s *SmartRollupRefuteStep) UnmarshalJSON(buf []byte) error {
 		s.Proof = &SmartRollupProof{}
 		return json.Unmarshal(buf, s.Proof)
 	default:
-		return fmt.Errorf("Invalid refute step data %q", string(buf))
+		return fmt.Errorf("invalid refute step data %q", string(buf))
 	}
 }
 
@@ -180,7 +180,7 @@ func (s *GameStatus) UnmarshalJSON(buf []byte) error {
 		a := wrapper{alias(s)}
 		_ = json.Unmarshal(buf, &a)
 	default:
-		return fmt.Errorf("Invalid game status data %q", string(buf))
+		return fmt.Errorf("invalid game status data %q", string(buf))
 	}
 	return nil
 }

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -23,7 +23,7 @@ type Transaction struct {
 func (t Transaction) Costs() tezos.Costs {
 	res := t.Metadata.Result
 	cost := tezos.Costs{
-		Fee:         t.Manager.Fee,
+		Fee:         t.Fee,
 		GasUsed:     res.Gas(),
 		StorageUsed: res.PaidStorageSizeDiff,
 	}

--- a/rpc/transfer_ticket.go
+++ b/rpc/transfer_ticket.go
@@ -25,7 +25,7 @@ type TransferTicket struct {
 func (t TransferTicket) Costs() tezos.Costs {
 	res := t.Metadata.Result
 	cost := tezos.Costs{
-		Fee:     t.Manager.Fee,
+		Fee:     t.Fee,
 		GasUsed: res.Gas(),
 	}
 	if !t.Result().IsSuccess() {

--- a/rpc/update_consensus_key.go
+++ b/rpc/update_consensus_key.go
@@ -19,7 +19,7 @@ type UpdateConsensusKey struct {
 // Costs returns operation cost to implement TypedOperation interface.
 func (t UpdateConsensusKey) Costs() tezos.Costs {
 	return tezos.Costs{
-		Fee:     t.Manager.Fee,
+		Fee:     t.Fee,
 		GasUsed: t.Metadata.Result.Gas(),
 	}
 }

--- a/tezos/crypto.go
+++ b/tezos/crypto.go
@@ -80,7 +80,7 @@ func ecPrivateKeyFromBytes(b []byte, curve elliptic.Curve) (key *ecdsa.PrivateKe
 	}
 
 	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/crypto/ecdsa/ecdsa.go;l=149
-	priv.PublicKey.X, priv.PublicKey.Y = curve.ScalarBaseMult(k.Bytes())
+	priv.X, priv.Y = curve.ScalarBaseMult(k.Bytes())
 	return priv, nil
 }
 
@@ -174,7 +174,7 @@ func encryptPrivateKey(key []byte, fn PassphraseFunc) ([]byte, error) {
 		return nil, ErrPassphrase
 	}
 
-	salt := make([]byte, 8)
+	salt := make([]byte, 8, 8+len(key)+secretbox.Overhead)
 	_, err = rand.Read(salt)
 	if err != nil {
 		return nil, err

--- a/tezos/key.go
+++ b/tezos/key.go
@@ -587,7 +587,7 @@ func (k PrivateKey) Public() Key {
 			pk.Type = KeyTypeInvalid
 			return pk
 		}
-		pk.Data = elliptic.MarshalCompressed(curve, ecKey.PublicKey.X, ecKey.PublicKey.Y)
+		pk.Data = elliptic.MarshalCompressed(curve, ecKey.X, ecKey.Y)
 	case KeyTypeBls12_381:
 		// TODO
 	}


### PR DESCRIPTION
## Summary

Master CI has been red since #91's golangci v1→v2 config migration. This PR makes it green again **without disabling any lint rule**.

### Root cause 1 — config migration bug (24 of the findings)

In golangci **v2**, `exclusions.paths` entries are regexes matched against **file paths**. The migrated `examples$` only matches a path *ending* in "examples", so `examples/**` was linted despite the config's own intent (v1 `skip-dirs` semantics matched the directory). Fixed to `^examples/` (+ same for the `third_party`/`builtin` boilerplate).

### Root cause 2 — real findings in core packages (all mechanical)

| Rule | Fix | Files |
|------|-----|-------|
| `QF1008` redundant embedded selector | `o.Manager.EncodeJSON` → `o.EncodeJSON` (codec ×14), `d.Manager.Fee` → `d.Fee` (rpc ×9), `ValueSource`/`Prim`/`PublicKey` selectors | codec, rpc, internal/compose, micheline, tezos |
| `govet inline` | deprecated `reflect.Ptr` → `reflect.Pointer` (×15) | contract/bind, micheline |
| `ST1005` | lowercase error strings (×5; test expectations updated) | cmd, codec, micheline, rpc |
| `QF1001`/`QF1003` | De Morgan / tagged switch | micheline |
| `prealloc` | preallocate `salt` capacity | tezos/crypto.go |

All call/field resolution is unchanged. Sites where dropping a selector **would** change resolution were deliberately left alone (e.g. `Script.Validate` calling `s.ValueSource.Validate` — dropping it would self-recurse; staticcheck correctly doesn't flag those).

### Workflow hardening

- **Pin `golangci-lint` to `v2.12.2`** (the version CI resolved from `latest`). `version: latest` means lint results drift with every linter release — that's exactly how this breakage shipped silently.
- **`fail-fast: false`** so one failing job no longer cancels and masks the other six matrix jobs (the "everything is red" effect).

## Verification

- `golangci-lint v2.12.2 run --max-issues-per-linter 0 --max-same-issues 0 ./...` → **zero findings** in tracked files (note: CI's default caps had been hiding ~37 findings beyond the annotations shown in the UI)
- `go build ./...`, `gofmt -s` clean, full `go test ./...` green

Unblocks PRs #98–#102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)